### PR TITLE
Fixed typo in loadDataProcess6 in dataProcessor.py --> Ribs load correctly now

### DIFF
--- a/Database/databaseClasses.py
+++ b/Database/databaseClasses.py
@@ -2317,15 +2317,19 @@ class Panel(StrawLocation):
     def recordFrame(self, number):
         self._recordPart("FRAME", number)
 
+    # gets LEFT rib
     def getMiddleRib1(self):
         return self._queryPartOnPanel("MIDDLERIB_1").one_or_none()
 
+    # records LEFT rib
     def recordMiddleRib1(self, number):
         self._recordPart("MIDDLERIB_1", number)
 
+    # gets RIGHT rib
     def getMiddleRib2(self):
         return self._queryPartOnPanel("MIDDLERIB_2").one_or_none()
 
+    # records RIGHT rib
     def recordMiddleRib2(self, number):
         self._recordPart("MIDDLERIB_2", number)
 

--- a/GUIS/panel/current/dataProcessor.py
+++ b/GUIS/panel/current/dataProcessor.py
@@ -2395,7 +2395,7 @@ class SQLDataProcessor(DataProcessor):
             self.getBarcode(panel),  # Panel
             self.getBarcode(panel.getFrame()),  # Frame
             self.getBarcode(panel.getMiddleRib1()),  # Left Middle Rib
-            self.getBarcode(panel.getMiddleRib1()),  # Right Middle Rib
+            self.getBarcode(panel.getMiddleRib2()),  # Right Middle Rib
             self.procedure.getBaseplateRibsMIRGapLeft(),  # Baseplate Ribs\MIR Gap (left)
             self.procedure.getBaseplateRibsMIRGapRight(),  # Baseplate Ribs\MIR Gap (right)
             self.epoxyBarcode(


### PR DESCRIPTION
- Using getMiddleRib1 gets the left rib, and it was being used to load data for the right rib
- Now it uses getMiddleRib2
- Also added comments to databaseClasses, to define the behavior of the getMiddleRib funcitons; I would have changed the names to be more descriptive, but I don't know if the funcitons are used in files other than PANGUI and dataProcessor