### PR TITLE
Latest Panel Heater Version from Kate (1009)

### DIFF
--- a/GUIS/panel/current/tension_devices/panel_heater/heat_control_window.py
+++ b/GUIS/panel/current/tension_devices/panel_heater/heat_control_window.py
@@ -52,7 +52,7 @@ class Ui_MainWindow(object):
         self.label_2.setObjectName("label_2")
         self.tempPA = QtWidgets.QLineEdit(self.centralwidget)
         self.tempPA.setEnabled(True)
-        self.tempPA.setGeometry(QtCore.QRect(740, 110, 141, 51))
+        self.tempPA.setGeometry(QtCore.QRect(740, 100, 141, 51))
         font = QtGui.QFont()
         font.setPointSize(12)
         font.setBold(True)
@@ -61,7 +61,7 @@ class Ui_MainWindow(object):
         self.tempPA.setReadOnly(True)
         self.tempPA.setObjectName("tempPA")
         self.label_3 = QtWidgets.QLabel(self.centralwidget)
-        self.label_3.setGeometry(QtCore.QRect(740, 50, 151, 71))
+        self.label_3.setGeometry(QtCore.QRect(740, 40, 151, 71))
         font = QtGui.QFont()
         font.setPointSize(12)
         font.setBold(True)
@@ -80,7 +80,7 @@ class Ui_MainWindow(object):
         self.label_4.setObjectName("label_4")
         self.tempP2 = QtWidgets.QLineEdit(self.centralwidget)
         self.tempP2.setEnabled(True)
-        self.tempP2.setGeometry(QtCore.QRect(740, 250, 141, 51))
+        self.tempP2.setGeometry(QtCore.QRect(740, 220, 141, 51))
         font = QtGui.QFont()
         font.setPointSize(12)
         font.setBold(True)
@@ -89,7 +89,7 @@ class Ui_MainWindow(object):
         self.tempP2.setReadOnly(True)
         self.tempP2.setObjectName("tempP2")
         self.label_6 = QtWidgets.QLabel(self.centralwidget)
-        self.label_6.setGeometry(QtCore.QRect(740, 190, 151, 71))
+        self.label_6.setGeometry(QtCore.QRect(740, 160, 151, 71))
         font = QtGui.QFont()
         font.setPointSize(12)
         font.setBold(True)
@@ -110,7 +110,7 @@ class Ui_MainWindow(object):
         self.end_data.setFont(font)
         self.end_data.setObjectName("end_data")
         self.label_5 = QtWidgets.QLabel(self.centralwidget)
-        self.label_5.setGeometry(QtCore.QRect(740, 290, 171, 141))
+        self.label_5.setGeometry(QtCore.QRect(740, 280, 161, 161))
         self.label_5.setWordWrap(True)
         self.label_5.setObjectName("label_5")
         self.label_7 = QtWidgets.QLabel(self.centralwidget)
@@ -122,7 +122,7 @@ class Ui_MainWindow(object):
         self.label_7.setFont(font)
         self.label_7.setObjectName("label_7")
         self.label_8 = QtWidgets.QLabel(self.centralwidget)
-        self.label_8.setGeometry(QtCore.QRect(90, 190, 51, 51))
+        self.label_8.setGeometry(QtCore.QRect(130, 190, 51, 51))
         font = QtGui.QFont()
         font.setPointSize(12)
         font.setBold(True)
@@ -137,11 +137,12 @@ class Ui_MainWindow(object):
         self.labelsp.setWordWrap(True)
         self.labelsp.setObjectName("labelsp")
         self.setpt_box = QtWidgets.QComboBox(self.centralwidget)
-        self.setpt_box.setGeometry(QtCore.QRect(20, 200, 61, 31))
+        self.setpt_box.setGeometry(QtCore.QRect(20, 200, 101, 31))
         font = QtGui.QFont()
         font.setPointSize(12)
         self.setpt_box.setFont(font)
         self.setpt_box.setObjectName("setpt_box")
+        self.setpt_box.addItem("")
         self.setpt_box.addItem("")
         self.setpt_box.addItem("")
         self.label_9 = QtWidgets.QLabel(self.centralwidget)
@@ -182,7 +183,7 @@ class Ui_MainWindow(object):
         self.label_5.setText(
             _translate(
                 "MainWindow",
-                "Calibration: PAAS-B/C RTDs in corners where temperature can be 5-8C lower than bulk surface. Expect apparent 5-8C difference with PAAS-A reading, due to calibration such that bulk surface will track PAAS-A to within 5C.",
+                "<html><head/><body><p>Calibration: PAAS RTDs are in peripheral locations where temperature can be 5-8C lower than bulk surface. Heat control program corrects for this such that bulk surfaces reach selected setpoint and track each other within 5C. Thus expect RTD readings in plot to be lower than 55C setpoint. Bulk surface temperature can be verified with thermocouples.</p></body></html>",
             )
         )
         self.label_7.setText(_translate("MainWindow", "Temperature Setpoint"))
@@ -193,8 +194,9 @@ class Ui_MainWindow(object):
             )
         )
         self.labelsp.setText(_translate("MainWindow", "Current setpoint:"))
-        self.setpt_box.setItemText(0, _translate("MainWindow", "55"))
-        self.setpt_box.setItemText(1, _translate("MainWindow", "34"))
+        self.setpt_box.setItemText(0, _translate("MainWindow", "Select..."))
+        self.setpt_box.setItemText(1, _translate("MainWindow", "55"))
+        self.setpt_box.setItemText(2, _translate("MainWindow", "34"))
         self.label_9.setText(
             _translate(
                 "MainWindow",

--- a/GUIS/panel/current/tension_devices/panel_heater/heat_control_window.ui
+++ b/GUIS/panel/current/tension_devices/panel_heater/heat_control_window.ui
@@ -125,7 +125,7 @@
     <property name="geometry">
      <rect>
       <x>740</x>
-      <y>110</y>
+      <y>100</y>
       <width>141</width>
       <height>51</height>
      </rect>
@@ -145,7 +145,7 @@
     <property name="geometry">
      <rect>
       <x>740</x>
-      <y>50</y>
+      <y>40</y>
       <width>151</width>
       <height>71</height>
      </rect>
@@ -194,7 +194,7 @@
     <property name="geometry">
      <rect>
       <x>740</x>
-      <y>250</y>
+      <y>220</y>
       <width>141</width>
       <height>51</height>
      </rect>
@@ -214,7 +214,7 @@
     <property name="geometry">
      <rect>
       <x>740</x>
-      <y>190</y>
+      <y>160</y>
       <width>151</width>
       <height>71</height>
      </rect>
@@ -270,13 +270,13 @@
     <property name="geometry">
      <rect>
       <x>740</x>
-      <y>290</y>
-      <width>171</width>
-      <height>141</height>
+      <y>280</y>
+      <width>161</width>
+      <height>161</height>
      </rect>
     </property>
     <property name="text">
-     <string>Calibration: PAAS-B/C RTDs in corners where temperature can be 5-8C lower than bulk surface. Expect apparent 5-8C difference with PAAS-A reading, due to calibration such that bulk surface will track PAAS-A to within 5C.</string>
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Calibration: PAAS RTDs are in peripheral locations where temperature can be 5-8C lower than bulk surface. Heat control program corrects for this such that bulk surfaces reach selected setpoint and track each other within 5C. Thus expect RTD readings in plot to be lower than 55C setpoint. Bulk surface temperature can be verified with thermocouples.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
     </property>
     <property name="wordWrap">
      <bool>true</bool>
@@ -305,7 +305,7 @@
    <widget class="QLabel" name="label_8">
     <property name="geometry">
      <rect>
-      <x>90</x>
+      <x>130</x>
       <y>190</y>
       <width>51</width>
       <height>51</height>
@@ -348,7 +348,7 @@
      <rect>
       <x>20</x>
       <y>200</y>
-      <width>61</width>
+      <width>101</width>
       <height>31</height>
      </rect>
     </property>
@@ -357,6 +357,11 @@
       <pointsize>12</pointsize>
      </font>
     </property>
+    <item>
+     <property name="text">
+      <string>Select...</string>
+     </property>
+    </item>
     <item>
      <property name="text">
       <string>55</string>


### PR DESCRIPTION
Changes to the GUI seem to be (1) slightly new way of parsing ino data and (2) ability to change the setpoint.

Kate's explanation of the further changes to the .ino code:
> Based on calibration tests, 52C at the RTD location corresponds to 55C on the PAAS-A bulk surface, which is explained in the GUI  - see text in GUI screenshot attached in Ken's email.
> Also, the 5hr software timer applies to either setpoint individually. During the funnels process, the setpoint will be increased from 34C to 55C before the timer for the 34C setpoint runs out. When the PAASs reach 55C, a new timer starts and will hold at 55C for 5hrs.

![PAAS-A_timer](https://user-images.githubusercontent.com/17835077/99568973-b0529480-2995-11eb-8b02-a5023555606d.png)
