### PR TITLE
Modified PANGUI.bat to write terminal log to a txt file

### DIFF
--- a/GUIS/panel/current/PANGUI.bat
+++ b/GUIS/panel/current/PANGUI.bat
@@ -16,4 +16,4 @@ set CUR_MS=%time:~9,2
 set SUBFILENAME=%CUR_YYYY%%CUR_MM%%CUR_DD%-%CUR_HH%%CUR_NN%%CUR_SS% 
 
 CD C:\Users\%USERNAME%\Desktop\Production\GUIS\panel\current
-python PANGUI.py > C:\Users\%USERNAME%\Desktop\MergeDownLogs\log_file_%SUBFILENAME%.txt 2>&1
+python PANGUI.py > C:\Users\%USERNAME%\Desktop\MergeDownLogs\PANGUI_log_%SUBFILENAME%.txt 2>&1


### PR DESCRIPTION
Modified the bat file for PANGUI to write logs to a text file in the MergeDownLogs directory

The file is saved as (assuming it was creating today at 3:21pm): log_file_20202011_152150.txt