### PR TITLE
Bugfix for the wire tensioner ino code

### DIFF
--- a/GUIS/panel/current/tension_devices/wire_tensioner/motor_loadcell_0326/motor_loadcell_0326.ino
+++ b/GUIS/panel/current/tension_devices/wire_tensioner/motor_loadcell_0326/motor_loadcell_0326.ino
@@ -51,12 +51,12 @@ void loop() {
           motor.Power(1);
           motor.SetDir("PULL");
           motor.SetStep(1);
-          while ((load_cell.get_units()+tare50*ref_mass_50)<(pretension-2.0) && motor.Position()<motor_maximum){
-            motor.Step((pretension-(load_cell.get_units()+tare50*ref_mass_50))/4); // four steps to get to approx. tension
+          while ((load_cell.get_units()+tare50*ref_mass_50)<(pretension-4.0) && motor.Position()<motor_maximum){
+            motor.Step((pretension-(load_cell.get_units()+tare50*ref_mass_50))/4); // steps to get to approx. tension
           }
           //display_status(); // custom display status so GUI can record pretension value - see below
           while ((load_cell.get_units()+tare50*ref_mass_50)<pretension && motor.Position()<motor_maximum){
-            motor.SetStep(4);
+            motor.SetStep(1);
             motor.Step(1);
           }
           //display_status(); // custom display status so GUI can record pretension value
@@ -134,27 +134,28 @@ void tensionwire(float set_tension){
       motor.Power(1);
       motor.SetDir("PULL");
       motor.SetStep(1);
-      while ((load_cell.get_units()+tare50*ref_mass_50)<(set_tension-2.0) && motor.Position()<motor_maximum){
+      while ((load_cell.get_units()+tare50*ref_mass_50)<(set_tension-6.0) && motor.Position()<motor_maximum){
         motor.Step((set_tension-(load_cell.get_units()+tare50*ref_mass_50))/4); // steps to get to approx. tension
       }
       display_status();
       while ((load_cell.get_units()+tare50*ref_mass_50)<set_tension && motor.Position()<motor_maximum){
         motor.SetStep(8);   // get last 2 grams of tension with 1/8th motor steps
         motor.Step(1);
+        //display_status();
       }
-      display_status();
     } 
     else if ((load_cell.get_units()+tare50*ref_mass_50)>set_tension){
       motor.Power(1);
       motor.SetDir("PUSH");
       motor.SetStep(1);
-      while ((load_cell.get_units()+tare50*ref_mass_50)>(set_tension+2.0) && motor.Position()>motor_minimum){
+      while ((load_cell.get_units()+tare50*ref_mass_50)>(set_tension+6.0) && motor.Position()>motor_minimum){
         motor.Step(((load_cell.get_units()+tare50*ref_mass_50)-set_tension)/4);
       } 
       display_status();
       while ((load_cell.get_units()+tare50*ref_mass_50)>set_tension && motor.Position()>motor_minimum){
         motor.SetStep(8);
         motor.Step(1);
+        //display_status();
       }
       display_status();
     }


### PR DESCRIPTION
My latest wire tensioner updates didn't work – python hung indefinitely whenever you tensioned a wire. Here's what happened:

Let's call the wire tensioner ino code that was originally committed to this repo **version 0**.
That makes the version that's been _in the lab, on the boxes_ **version 1**.

Well, something in version 0 is incompatible with the current guis and/or hardware, and this something led to indefinite hanging when you attempt to tension a wire.

The recent version of the wire tensioner ino code (call it **version 3**) used version _0_ as a starting point, and the aforementioned incompatible something propagated its way into version 3, causing the problems we saw. We got extra confused because I attempted to revert GUI and ino code to version 0, but that didn't work either! Well that was confusing because we didn't know that version 1 existed and was installed on all the boxes.

It's still a mystery how I ever had my new version working, which Farhan agrees was working. Best guess is that the "incompatibility" is related to hardware such that it causes failures at or near realistic wire tensions, and our test setup had probably unrealistic tensions that we never tried to calibrate. Yeah, that seems pretty plausible.

I ultimately found the incompatible change when I got a hold of some version 1 code from Kate.

Here's the "incompatible" change, in Kate's words: "adjustment of parameters in conjuction with wire breakage tests, which I think correspondeds to the threshold changes for motor steps"