### PR TITLE
Updates to databaseviewer database access

### DIFF
--- a/GUIS/databaseViewer/facileDBMain.py
+++ b/GUIS/databaseViewer/facileDBMain.py
@@ -132,7 +132,8 @@ class facileDBGUI(QMainWindow):
 
         # Test RO mode. This SHOULD throw an exception.
         try:
-            bad_query = "create table bar (id integer)"
+            # although a write command, I think it does NOTHING
+            bad_query = "PRAGMA user_version=0"
             self.connection.execute(bad_query)
         except sqla.exc.OperationalError:  # "attempt to write a readonly database"
             # RO mode working as expected


### PR DESCRIPTION
Combine the two connect-to-database functions into one.

Instead of hard-coding database paths, access the txt database path files in the database/ folder, like all of our
other guis do.

Add comments to and beef up the read-only connection section. If not in RO mode, then quit.