### PR TITLE
TB power issues lead to NaN pulse widths

### DIFF
--- a/GUIS/panel/current/tension_devices/tension_box/tensionbox_window.py
+++ b/GUIS/panel/current/tension_devices/tension_box/tensionbox_window.py
@@ -255,7 +255,11 @@ class TensionBox(QMainWindow, tensionbox_ui.Ui_MainWindow):
             # Write out the desired pulse width
             # Arduino code must be updated to know to accept this
 
-            self.ser.write(bytes(str(float(pulse_width)) + "\n", "UTF-8"))
+            try:
+                self.ser.write(bytes(str(int(pulse_width)) + "\n", "UTF-8"))
+            except ValueError:
+                print("NaN Pulse Width! In the past, this has been caused by "
+                      "a power issue -- not enough power, broken barrel jack.")
             self.ser.readline()  # Read in the line where Arduino echos trigger
 
             # Read in the line where Arduino prints the pulse width, and print it out once per iteration

--- a/GUIS/panel/current/tension_devices/tension_box/vibrator/vibrator.ino
+++ b/GUIS/panel/current/tension_devices/tension_box/vibrator/vibrator.ino
@@ -1,12 +1,6 @@
-   /*
- * vibrator
- *
- * Arduino code used for vibrating the string or straw for tension measurements.
- * 
- * created by Vadim Rusu (vrusu@fnal.gov)
- * edited 09 February 2016
- * by Lauren Yates (yatesla@fnal.gov)
- */
+
+// based on:
+// Arduino code to vibrate the string/straw. vrusu@fnal.gov
 
 #include <Wire.h>
 #include <stdint.h>
@@ -15,9 +9,6 @@
 
 const int enable = 8;
 const int enabledigi = 9;
-//try reversing:
-//const int enable = 9;
-//const int enabledigi = 8;
 
 const int convst = 10;
 const int busy = 5;
@@ -173,7 +164,7 @@ void loop()
     {
       unsigned int tNow;
       while ((tNow = micros())<tNext) ;
-      tNext = tNow + 120;
+      tNext = tNow + 10; // noise 56Hz
       *pReading = readADC();
     }
     digitalWrite(dbgPin,LOW);


### PR DESCRIPTION
self.ser.write(bytes(str(int(pulse_width)) + n, UTF-8))
ValueError: cannot convert float NaN to integer

These errors appear when the TB arduino is having a power problem (not getting enough power is at least one of the problems).

This fix should at least give a different and hopefully more useful error. It can't be any less useful than it is now, anyway.