### PR TITLE
TA only holds at 46 until TB gets to 40 (decreased from 44).

### DIFF
--- a/guis/panel/heater/PAAS_heater/PAAS_heater.ino
+++ b/guis/panel/heater/PAAS_heater/PAAS_heater.ino
@@ -130,7 +130,7 @@ void temp_control(){
       // Heat A and B at full blast unless TA>=46 && (TB<40 || TA>44), in
       // which case use the default dT.
       if (setpointA>50) {
-        if(tempA>=46 && (temp2<40 || temp2>44){ ; }
+        if(tempA>=46 && (temp2<40 || temp2>44)){ ; }
         else dT=0;
       }
     }


### PR DESCRIPTION
Previous behavior was: TA holds at 46 until TB reaches about 44. We want TA to hold at 46 only until TB reaches 40. So add the specific constraint for (TA > 46 && TB < 44) to continue heating TA as soon as TB reaches 40. Above TB==44, we like the behavior, so keep it.