### PR TITLE
DB Locked Error Test Fix

### DIFF
--- a/guis/common/databaseManager.py
+++ b/guis/common/databaseManager.py
@@ -33,7 +33,7 @@ class DatabaseManager:
 
         ## Connect to Local SQL database
         self._Connection = dbconnection()
-        self._engine = create_engine(f"sqlite:///{self._local_db}")
+        self._engine = create_engine(f"sqlite:///{self._local_db}", pool_pre_ping=True)
         self._Connection.configure(bind=self._engine)
         self._init_connection()
 


### PR DESCRIPTION
Use the `create_engine` `pool_pre_ping` option to possibly fix the locked DB errors/crashes we've been seeing.

This is very much a test fix. I highly doubt this will break anything, but it may not solve the problem; thus I opt to test in production.

Possible outcomes: (1) fixes all locked DB problems, (2) fixes local commit lock errors but not automerge lock errors, (3) doesn't fix any lock errors.