### PR TITLE
Simple Heater Monitor

### DIFF
--- a/guis/panel/heater/PAAS_heater/PAAS_heater.ino
+++ b/guis/panel/heater/PAAS_heater/PAAS_heater.ino
@@ -23,8 +23,19 @@ float tempA;
 float temp2;
 float initial_temp2;
 float usrsp;  // user choice setpoint temperature 
-float max_temp = -9;
-float time_of_max_temp = -1;
+
+// Save key metrics in case monitor crashes
+float tempA_max = -99; // max temp
+uint32_t tempA_max_timestamp = 0; // time at which max temp was reached
+uint32_t tempA_setpt_timestamp = 0; // time setpoint was reaches
+uint32_t tempA_50_up_timestamp = 0; // time 50c was reached on the way up
+uint32_t tempA_40_dn_timestamp = 0; // time 40c was reached on the way down
+
+float temp2_max = -99;
+uint32_t temp2_max_timestamp = 0;
+uint32_t temp2_setpt_timestamp = 0;
+uint32_t temp2_50_up_timestamp = 0;
+uint32_t temp2_40_dn_timestamp = 0;
 
 float setpoint2;  
 char paas2='x'; // placeholder for user choice of 2nd PAAS type
@@ -154,18 +165,61 @@ void temp_control(){
 	FastPwm(valA,valB); 
 }
 
+void set_key_metrics(float temp_A, float temp_2, uint32_t now){
+	if(tempA_max < temp_A){ // A max temp
+		tempA_max_timestamp = now;
+		tempA_max = temp_A;
+	}
+	if(temp2_max < temp_2){ // 2 max temp
+		temp2_max_timestamp = now;
+		temp2_max = temp_2;
+	}
+	if(temp_A == setpointA){ // A set point time
+		tempA_setpt_timestamp = now;
+	}
+	if(temp_2 == setpoint2){ // 2 set point time
+		temp2_setpt_timestamp = now;
+	}
+	if(temp_A > 50 && tempA_setpt_timestamp <= 1){ // A rises to 50
+		tempA_50_up_timestamp  = now;
+	}
+	if(temp_2 > 50 && temp2_setpt_timestamp <= 1){ // 2 rises to 50
+		temp2_50_up_timestamp  = now;
+	}
+	if(temp_A < 40 && tempA_setpt_timestamp > 1 && tempA_40_dn_timestamp <= 1){ // A falls to 40
+		tempA_40_dn_timestamp  = now;
+	}
+	if(temp_2 < 40 && temp2_setpt_timestamp > 1 && temp2_40_dn_timestamp <= 1){ // 2 falls to 40
+		temp2_40_dn_timestamp  = now;
+	}
+}
+
 void display_status(){
 	//Serial.println("PAAS-B: RTD in corner -> expect lower temperature than surface");
 	//Serial.println("PAAS-C: testing calibration -> expect apparent temp. diff. up to 5C");
-	if(max_temp < maxamp.temperature(RNOMINAL_PTCO, RREF)){
-		max_temp = maxamp.temperature(RNOMINAL_PTCO, RREF)
+	float temp_A = maxamp.temperature(RNOMINAL_PTCO, RREF);
+	float temp_2 = -99;
+	uint32_t now = millis();
+	if(paas2!='0'){
+		temp_2 = maxamp2.temperature(RNOMINAL_PTCO2, RREF);
 	}
-	Serial.print("Temperature 1: "); Serial.println(maxamp.temperature(RNOMINAL_PTCO, RREF));
-	Serial.print("Temperature 2: "); Serial.println(maxamp2.temperature(RNOMINAL_PTCO2, RREF));
-	Serial.print("Max Temp: "); Serial.println(max_temp);
+	set_key_metrics(temp_A, temp_2, now);
+	Serial.print("Temperature 1: "); Serial.println(temp_A);
+	Serial.print("Temperature 2: "); Serial.println(temp_2);
 	Serial.print("Time = ");Serial.println(millis());
 	//Serial.print("state = ");Serial.println(state); // test for software timer fix
+
+	Serial.print("Temp A max = "); Serial.println(tempA_max);
+	Serial.print("Temp A max timestamp = "); Serial.println(tempA_max_timestamp);
+	Serial.print("Temp A reach setpoint timestamp = "); Serial.println(tempA_setpt_timestamp);
+	Serial.print("Temp A rises to 50 timestamp = "); Serial.println(tempA_50_up_timestamp);
+	Serial.print("Temp A falls to 40 timestamp = "); Serial.println(tempA_40_dn_timestamp);
+
+	Serial.print("Temp 2 max = "); Serial.println(temp2_max);
+	Serial.print("Temp 2 max timestamp = "); Serial.println(temp2_max_timestamp);
+	Serial.print("Temp 2 reach setpoint timestamp = "); Serial.println(temp2_setpt_timestamp);
+	Serial.print("Temp 2 rises to 50 timestamp = "); Serial.println(temp2_50_up_timestamp);
+	Serial.print("Temp 2 falls to 40 timestamp = "); Serial.println(temp2_40_dn_timestamp);
+
 	delay(10);
 }
-
-

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -33,7 +33,7 @@ from matplotlib.figure import Figure
 
 
 class HeatControl(QMainWindow):
-    """ Python interface to collect and visualize data from PAAS heater control system """
+    """Python interface to collect and visualize data from PAAS heater control system"""
 
     def __init__(
         self, port, panel, wait=120000, ndatapts=450, parent=None, saveMethod=None
@@ -76,7 +76,7 @@ class HeatControl(QMainWindow):
         print("last temperature measurements:", self.tempArec[-1], self.temp2rec[-1])
 
     def selectpaas(self):
-        """ Enable start data collection if both 2nd PAAS and setpoint selected """
+        """Enable start data collection if both 2nd PAAS and setpoint selected"""
         if (
             self.ui.paas2_box.currentText() != "Select..."
             and self.ui.setpt_box.currentText() != "Select..."
@@ -101,7 +101,7 @@ class HeatControl(QMainWindow):
             self.ui.labelsp.setText(f"Current setpoint: {self.setpt}C")
 
     def start_data(self):
-        """ Start serial interface and data collection thread """
+        """Start serial interface and data collection thread"""
         self.ui.start_button.setDisabled(True)
         self.ui.paas2_box.setDisabled(True)
         self.ui.setpt_box.removeItem(0)  # cannot revert to 'Select...'
@@ -132,7 +132,7 @@ class HeatControl(QMainWindow):
 
     # In this function: pass temperatures out to PANGUI
     def next(self):
-        """ Add next data to the GUI display """
+        """Add next data to the GUI display"""
         ## get the most recent measurement held in thread
         data_list = list(self.hct.transfer())
         if len(data_list) > 0:  # should only have one set of measurements
@@ -158,7 +158,7 @@ class HeatControl(QMainWindow):
             self.saveMethod(self.tempArec[-1], self.temp2rec[-1])
 
     def testplot3(self):
-        """ Set up canvas for plotting temperature vs. time """
+        """Set up canvas for plotting temperature vs. time"""
         self.ui.data_widget = QWidget(self.ui.graphicsView)
         layout = QHBoxLayout(self.ui.graphicsView)
         self.z = np.array([[-10, -10]])
@@ -175,17 +175,17 @@ class HeatControl(QMainWindow):
         self.ui.data_widget.repaint()
 
     def testplot2(self):
-        """ Update plot: new [time,temperature] array """
+        """Update plot: new [time,temperature] array"""
         self.z = np.array([self.timerec, self.tempArec, self.temp2rec]).T
         self.canvas.read_data(self.z, self.paas2input)
         self.ui.data_widget.repaint()
 
     def closeEvent(self, event):
-        """ Prevent timer and thread from outliving main window, close serial """
+        """Prevent timer and thread from outliving main window, close serial"""
         self.endtest()
 
     def endtest(self):
-        """ Join data collection thread to end or reset test """
+        """Join data collection thread to end or reset test"""
         self.interval.stop()
         if self.hct:  ## must stop thread if it's running
             self.hct.join(0.1)  ## make thread timeout
@@ -193,7 +193,7 @@ class HeatControl(QMainWindow):
 
 
 class DataThread(threading.Thread):
-    """ Read data from Arduino in temperature control box """
+    """Read data from Arduino in temperature control box"""
 
     def __init__(self, micro, panel, paastype, setpoint):
         threading.Thread.__init__(self)
@@ -235,7 +235,7 @@ class DataThread(threading.Thread):
                     continue
                 if "val" in test:  # duty cycle 0-255 for voltage control
                     logger.info(test.strip())
-                elif "Temp" in test:  # temperature reading
+                elif "Temperature" in test:  # temperature reading
                     test = test.strip().split()
                     try:
                         float(test[-1])
@@ -377,4 +377,7 @@ def run():
 
 
 if __name__ == "__main__":
+    from guis.common.panguilogger import SetupPANGUILogger
+
+    logger = SetupPANGUILogger("root", "HeaterStandalone")
     run()

--- a/guis/panel/heater/__main__.py
+++ b/guis/panel/heater/__main__.py
@@ -1,4 +1,9 @@
 import guis.panel.heater.PanelHeater as heatergui
+import guis.panel.heater.simple_monitor as monitor
+from sys import argv
 
 if __name__ == "__main__":
-    heatergui.run()
+    if len(argv) > 1:
+        monitor.run()
+    else:
+        heatergui.run()

--- a/guis/panel/heater/simple_monitor.py
+++ b/guis/panel/heater/simple_monitor.py
@@ -8,8 +8,6 @@ import numpy as np
 import traceback
 import threading
 
-# from PyQt5.QtCore import QTimer
-
 import logging
 
 logger = logging.getLogger("root")
@@ -38,40 +36,12 @@ class HeatControl:
         self.tempArec = []  # PAAS-A temperature [C]
         self.temp2rec = []  # 2nd PAAS temperature [C]
 
-        """
-        ## set up GUI
-        self.ui = Ui_MainWindow()
-        self.ui.setupUi(self)
-        self.ui.start_button.clicked.connect(self.start_data)
-
-        ## 2nd PAAS type selection required before start of data collection
-        self.ui.paas2_box.currentIndexChanged.connect(self.selectpaas)
-        self.ui.setpt_box.currentIndexChanged.connect(self.selectpaas)
-        self.ui.start_button.setDisabled(True)
-        self.ui.end_data.clicked.connect(self.endtest)
-
-        ## user choice temperature setpoint
-        self.ui.setpt_box.currentIndexChanged.connect(self.update_setpoint)
-        """
         logger.info("initialized")
 
     def saveMethod_placeholder(self):
         ## self.tempArec = PAAS-A temperatures
         ## self.temp2rec = PAAS-B or PAAS-C temperatures
         print("last temperature measurements:", self.tempArec[-1], self.temp2rec[-1])
-
-    '''
-    def selectpaas(self):
-        """ Enable start data collection if both 2nd PAAS and setpoint selected """
-        if (
-            self.ui.paas2_box.currentText() != "Select..."
-            and self.ui.setpt_box.currentText() != "Select..."
-            and self.ui.paas2_box.isEnabled()
-        ):
-            self.ui.start_button.setEnabled(True)
-        else:
-            self.ui.start_button.setDisabled(True)
-    '''
 
     def update_setpoint(self):
         """Get initial user choice temperature setpoint, or change setpoint
@@ -280,7 +250,7 @@ def getport(hardwareID):
 def run():
     from guis.common.panguilogger import SetupPANGUILogger
 
-    logger = SetupPANGUILogger("root", "HeaterStandalone")
+    logger = SetupPANGUILogger("root", "HeaterMonitor")
     # heater control uses Arduino Micro: hardware ID 'VID:PID=2341:8037'
     port = getport("VID:PID=2341:8037")
     logger.info("Arduino Micro at {}".format(port))


### PR DESCRIPTION
For when python or windows glitches out such that we lose data collection, this new script can be run the next morning to recover several key timestamps and temperatures, so we at least know that the panel doesn't need to be trashed.

Key times and temps are saved within the arduino code, which constantly spits out these values.

simple_monitor reconnects to the arduino and passes the values onto the console. So it's pretty crude at the moment.