### PR TITLE
Add Which Process to Heat CSV Data File

### DIFF
--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -202,7 +202,7 @@ class DataThread(threading.Thread):
         self.micro = micro
         self.paastype = paastype
         self.setpt = setpoint
-        outfilename = panel + "_" + dt.now().strftime("%Y-%m-%d") + ".csv"
+        outfilename = panel + "_" + dt.now().strftime("%Y-%m-%d") + "_" + paastype + ".csv"
         self.datafile = GetProjectPaths()["heatdata"] / outfilename
         ## create file if needed and write header
         if not self.datafile.is_file():

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -367,6 +367,12 @@ def getport(hardwareID):
 def run():
     # heater control uses Arduino Micro: hardware ID 'VID:PID=2341:8037'
     port = getport("VID:PID=2341:8037")
+
+    # When running standalone, overwrite the logger
+    from guis.common.panguilogger import SetupPANGUILogger
+
+    logger = SetupPANGUILogger("root", "HeaterStandalone")
+
     logger.info("Arduino Micro at {}".format(port))
 
     # view traceback if error causes GUI to crash
@@ -380,7 +386,4 @@ def run():
 
 
 if __name__ == "__main__":
-    from guis.common.panguilogger import SetupPANGUILogger
-
-    logger = SetupPANGUILogger("root", "HeaterStandalone")
     run()

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -202,7 +202,10 @@ class DataThread(threading.Thread):
         self.micro = micro
         self.paastype = paastype
         self.setpt = setpoint
-        outfilename = panel + "_" + dt.now().strftime("%Y-%m-%d") + "_" + paastype + ".csv"
+        proc_str = {"0": "pro1", "b": "pro2", "c": "pro6"}[paastype.decode()]
+        outfilename = (
+            panel + "_" + dt.now().strftime("%Y-%m-%d") + "_" + proc_str + ".csv"
+        )
         self.datafile = GetProjectPaths()["heatdata"] / outfilename
         ## create file if needed and write header
         if not self.datafile.is_file():


### PR DESCRIPTION
Was hard to parse heat csv files by eye without which process.

Doing this in advance of the `separate_heater` branch, which will benefit from the change.