### PR TITLE
Separate heater from pangui

### DIFF
--- a/guis/common/getresources.py
+++ b/guis/common/getresources.py
@@ -12,7 +12,7 @@ except ImportError:
     import importlib_resources as pkg_resources
 
 # Resources folder: where the paths.csv file is stored.
-import resources
+import resources, data
 
 
 # Get a dictionary containing the important paths for this project.
@@ -29,3 +29,8 @@ def GetProjectPaths():
     root = pkg_resources.read_text(resources, "rootDirectory.txt")
     paths.update((k, Path(root + "/" + v)) for k, v in paths.items())
     return paths
+
+
+def GetLocalDatabasePath():
+    with pkg_resources.path(data, "database.db") as p:
+        return str(p.resolve())

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -10,7 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import traceback
 import threading
-from tests.load_heat_csv_into_db import run as load_into_db
+from guis.panel.heater.load_heat_csv_into_db import run as load_into_db
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -85,15 +85,13 @@ class HeatControl(QMainWindow):
     def identifyStandaloneMode(self):
         import inspect
 
-        parents = inspect.stack()
+        parents = inspect.stack()  # who called PanelHeater?
+        # print("\n\n".join(str(i) for i in parents))
         is_standalone = len([i for i in parents if "launch_sa_heater" in str(i)])
         if is_standalone:
             logger.info("Heater launched separately from PANGUI.")
             logger.info("Live data will be saved to a txt file only.")
-            logger.info(
-                "When the End Data Collection button is pressed, the txt "
-                "data will be loaded into the local database."
-            )
+            logger.info("'End Data Collection' loads data to local DB.")
         elif len([i for i in parents if "pangui" in str(i)]):
             logger.warning("Heater launched as a child to PANGUI.")
             logger.warning(

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -64,7 +64,7 @@ class HeatControl(QMainWindow):
         self.ui.paas2_box.currentIndexChanged.connect(self.selectpaas)
         self.ui.setpt_box.currentIndexChanged.connect(self.selectpaas)
         self.ui.start_button.setDisabled(True)
-        self.ui.end_data.clicked.connect(self.endtest)
+        self.ui.end_data.clicked.connect(self.endtest)  # call join on thread
 
         ## user choice temperature setpoint
         self.ui.setpt_box.currentIndexChanged.connect(self.update_setpoint)
@@ -94,7 +94,7 @@ class HeatControl(QMainWindow):
             self.ui.labelsp.setText(f"Current setpoint: {self.setpt}C")
             # if thread already running, send it the new setpoint
             if self.hct:
-                logger.info("sending sp %s" % self.setpt)
+                logger.info(f"Sending new setpoint to arduino {self.setpt}")
                 self.hct.setpt = self.setpt
         else:  # for case with 'Select...' option (start will be disabled)
             self.setpt = 0
@@ -115,22 +115,24 @@ class HeatControl(QMainWindow):
         ## trigger paas2 input request
         time.sleep(0.2)
         self.micro.write(b"\n")
-        test = self.micro.readline()
-        while test == b"" or test == b"\r\n":  # skip blank lines if any
+        # skip blank lines if any (and then throw them away)
+        ino_line = self.micro.readline()
+        while ino_line == b"" or ino_line == b"\r\n":
             self.micro.write(b"\n")
-            test = self.micro.readline()
+            ino_line = self.micro.readline()
         ## send character that determines second PAAS plate
         self.paastype = paas2dict[self.paas2input].encode("utf8")
         ## plot will have time since start of test
         self.t0 = time.time()
 
         ## run data collection from separate thread to avoid freezing GUI
-        self.interval.timeout.connect(self.next)
+        self.interval.timeout.connect(self.next)  # call next @ every timeout
         self.hct = DataThread(self.micro, self.panel, self.paastype, self.setpt)
         self.hct.start()
-        self.interval.start(self.wait)  # get data at every timeout
+        self.interval.start(self.wait)  # begin timeouts every wait secs
 
     # In this function: pass temperatures out to PANGUI
+    # During every 'timeout', call this function
     def next(self):
         """Add next data to the GUI display"""
         ## get the most recent measurement held in thread
@@ -146,9 +148,9 @@ class HeatControl(QMainWindow):
                 self.temp2rec.append(0.0)  # (avoid -242 or 988)
             self.timerec.append((time.time() - self.t0) / 60.0)
             if len(self.timerec) > self.ndatapts:
-                self.endtest()
+                self.endtest()  # join thread if we've collected enough data
             else:
-                self.hct.savedata()
+                self.hct.savedata()  # to a csv file
                 ## update plot display
                 self.testplot2()
 
@@ -218,39 +220,42 @@ class DataThread(threading.Thread):
     def run(self):
         logger.info("thread running")
         n, nmax = 0, 40
+        # loop this endlessly until we press the "end data collection" button.
+        # each loop finishes in about 10 sec
         while self.running.isSet():
-            self.micro.write(self.paastype)
-            self.micro.write(str(self.setpt).encode("utf8"))
-            self.micro.write(b"\n")
-            ## extract measurements
+            # self.micro.write(self.paastype)
+            # self.micro.write(str(self.setpt).encode("utf8"))
+            # self.micro.write(b"\n")
+            # Read nmax (40) arduino lines until we get legit temp vals
             temp1, temp2 = "", ""
             while not (temp1 and temp2) and n < nmax:
-                test = self.micro.readline().decode("utf8")
-                if test == "":
+                ino_line = self.micro.readline().decode("utf8")
+                if ino_line == "":
                     n += 1
                     self.micro.write(self.paastype)
                     self.micro.write(str(self.setpt).encode("utf8"))
                     self.micro.write(b"\n")
                     continue
-                # print(repr(test))
-                if len(test.strip().split()) < 2:  # skip split line error
+                # print(repr(ino_line))
+                if len(ino_line.strip().split()) < 2:  # skip split line error
                     logger.info("skipping fragment of split line")
                     continue
-                if "val" in test:  # duty cycle 0-255 for voltage control
-                    logger.info(test.strip())
-                elif "Temperature" in test:  # temperature reading
-                    test = test.strip().split()
+                if "val" in ino_line:  # duty cycle 0-255 for voltage control
+                    logger.info(ino_line.strip())
+                elif "Temperature" in ino_line:  # temperature reading
+                    ino_line = ino_line.strip().split()
                     try:
-                        float(test[-1])
+                        float(ino_line[-1])
                     except ValueError:
                         logger.info("skipping fragment of split line")
                         continue
-                    if test[1] == "1:":
-                        temp1 = test[-1]  # PAAS-A temperature [C]
-                    elif test[1] == "2:":
-                        temp2 = test[-1]  # 2nd PAAS temperature [C]
+                    if ino_line[1] == "1:":
+                        temp1 = ino_line[-1]  # PAAS-A temperature [C]
+                    elif ino_line[1] == "2:":
+                        temp2 = ino_line[-1]  # 2nd PAAS temperature [C]
                 n += 1
                 time.sleep(1)
+
             if n == nmax:  # probable error with serial connection
                 logger.error("Error with serial connection ->")
                 # clear temps to not send old value if requested by GUI
@@ -264,6 +269,7 @@ class DataThread(threading.Thread):
                 self.temp1 = temp1
                 self.temp2 = temp2
                 n = 0
+
         logger.info("thread running check")
         ## close serial if thread joined
         if self.micro:

--- a/guis/panel/heater/PanelHeater.py
+++ b/guis/panel/heater/PanelHeater.py
@@ -10,6 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import traceback
 import threading
+from tests.load_heat_csv_into_db import run as load_into_db
 
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
@@ -204,10 +205,16 @@ class DataThread(threading.Thread):
         self.micro = micro
         self.paastype = paastype
         self.setpt = setpoint
-        proc_str = {"0": "pro1", "b": "pro2", "c": "pro6"}[paastype.decode()]
+        self.pro = {"0": 1, "b": 2, "c": 6}[paastype.decode()]
         outfilename = (
-            panel + "_" + dt.now().strftime("%Y-%m-%d") + "_" + proc_str + ".csv"
+            panel
+            + "_"
+            + dt.now().strftime("%Y-%m-%d")
+            + "_pro"
+            + str(self.pro)
+            + ".csv"
         )
+        self.panel = int(panel[2:])
         self.datafile = GetProjectPaths()["heatdata"] / outfilename
         ## create file if needed and write header
         if not self.datafile.is_file():
@@ -274,6 +281,11 @@ class DataThread(threading.Thread):
         ## close serial if thread joined
         if self.micro:
             self.micro.close()
+            try:
+                load_into_db(self.panel, self.pro)
+            except AssertionError as e:
+                print("failed")
+                print(e)
 
     def savedata(self):
         # print('setpoint in thread',self.setpt)

--- a/guis/panel/heater/__main__.py
+++ b/guis/panel/heater/__main__.py
@@ -2,4 +2,4 @@ import guis.panel.heater.launch_sa_heater as heatergui
 from sys import argv
 
 if __name__ == "__main__":
-    heatergui.run(sys.argv[1])
+    heatergui.run(argv[1])

--- a/guis/panel/heater/__main__.py
+++ b/guis/panel/heater/__main__.py
@@ -1,9 +1,5 @@
 import guis.panel.heater.launch_sa_heater as heatergui
-import guis.panel.heater.simple_monitor as monitor
 from sys import argv
 
 if __name__ == "__main__":
-    if len(argv) > 1:
-        monitor.run()
-    else:
-        heatergui.run()
+    heatergui.run(sys.argv[1])

--- a/guis/panel/heater/__main__.py
+++ b/guis/panel/heater/__main__.py
@@ -1,4 +1,4 @@
-import guis.panel.heater.PanelHeater as heatergui
+import guis.panel.heater.launch_sa_heater as heatergui
 import guis.panel.heater.simple_monitor as monitor
 from sys import argv
 

--- a/guis/panel/heater/launch_sa_heater.py
+++ b/guis/panel/heater/launch_sa_heater.py
@@ -7,7 +7,7 @@ from guis.panel.heater.PanelHeater import HeatControl
 from guis.common.panguilogger import SetupPANGUILogger
 from PyQt5.QtWidgets import QApplication
 import serial  ## from pyserial
-import sys, traceback, time
+import sys, traceback, time, re
 
 logger = SetupPANGUILogger("root", "HeaterStandalone")
 
@@ -27,11 +27,10 @@ def getport(hardwareID):
 
 # Return a string of length 3 of only numbers
 # Ignore any and all alphas
-def GetPanelFromUserInput():
-    while True:
+def check_panel_id(panelid):
+    if not panelid:  # none provided so get from user input
         panelid = input("Panel ID> ")
-        import re
-
+    while True:
         panelid = re.sub("[^0-9]", "", str(panelid))  # strip alphas
         try:
             assert 1 <= int(panelid) and int(panelid) <= 999
@@ -44,32 +43,15 @@ def GetPanelFromUserInput():
     return panelid
 
 
-def GetProcessFromUserInput():
-    while True:
-        pro = input(
-            "Which heating process?\n[1] Process 1, PAAS A only\n[2] Process 2, PAAS A and PAAS B\n[6] Process 6 PAAS A and PAAS C\n> "
-        )
-        try:
-            assert pro in [1, 2, 6]
-            break
-        except:
-            print("Invalid process, must be 1, 2, or 6")
-
-    return pro
-
-
-def run():
+def run(panelid=None):
 
     # heater control uses Arduino Micro: hardware ID 'VID:PID=2341:8037'
     port = getport("VID:PID=2341:8037")
 
     # which panel
-    panelid = GetPanelFromUserInput()
+    panelid = check_panel_id(panelid)
 
-    ##which process
-    # pro = GetProcessFromUserInput()
-
-    print(f"Heating panel MN{panelid}")  # , process {pro}.")
+    print(f"Heating panel MN{panelid}")
 
     logger.info("Arduino Micro at {}".format(port))
 
@@ -78,7 +60,7 @@ def run():
 
     # GUI
     app = QApplication(sys.argv)
-    ctr = HeatControl(port, panel=f"MN{panelid}", saveMethod=lambda a, b: None)
+    ctr = HeatControl(port, panel=f"MN{panelid}")
     ctr.show()
     app.exec_()
 

--- a/guis/panel/heater/launch_sa_heater.py
+++ b/guis/panel/heater/launch_sa_heater.py
@@ -66,4 +66,4 @@ def run(panelid=None):
 
 
 if __name__ == "__main__":
-    run()
+    run(sys.argv[1])

--- a/guis/panel/heater/launch_sa_heater.py
+++ b/guis/panel/heater/launch_sa_heater.py
@@ -1,0 +1,55 @@
+from guis.panel.heater.PanelHeater import HeatControl
+from guis.common.panguilogger import SetupPANGUILogger
+from PyQt5.QtWidgets import QApplication
+import serial  ## from pyserial
+import sys, traceback, time
+
+logger = SetupPANGUILogger("root", "HeaterStandalone")
+
+
+"""
+lambda temp_paas_a, temp_paas_bc: (
+    self.DP.savePanelTempMeasurement(temp_paas_a, temp_paas_bc)
+)
+"""
+
+
+def getport(hardwareID):
+    """Get COM port number. Distinguish Arduino types when multiple devices are connected
+    (also works on General Nanosystems where Arduinos recognized as "USB Serial")."""
+    ports = [
+        p.device for p in serial.tools.list_ports.comports() if hardwareID in p.hwid
+    ]
+    if len(ports) < 1:
+        logger.error("Arduino not found \nPlug device into any USB port")
+        time.sleep(2)
+        sys.exit()
+    return ports[0]
+
+
+def run():
+    # heater control uses Arduino Micro: hardware ID 'VID:PID=2341:8037'
+    port = getport("VID:PID=2341:8037")
+    logger.debug("Arduino Micro at {}".format(port))
+
+    # view traceback if error causes GUI to crash
+    sys.excepthook = traceback.print_exception
+
+    # Data Processor
+    self.DP = DataProcessor(
+        gui=self,
+        save2txt=SAVE_TO_TXT,
+        save2SQL=SAVE_TO_SQL,
+        lab_version=LAB_VERSION,
+        sql_primary=bool(PRIMARY_DP == "SQL"),
+    )
+
+    # GUI
+    app = QApplication(sys.argv)
+    ctr = HeatControl(port, panel="MN000")
+    ctr.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    run()

--- a/guis/panel/heater/launch_sa_heater.py
+++ b/guis/panel/heater/launch_sa_heater.py
@@ -73,7 +73,7 @@ def run():
 
     # GUI
     app = QApplication(sys.argv)
-    ctr = HeatControl(port, panel=f"MN{panelid}")
+    ctr = HeatControl(port, panel=f"MN{panelid}", saveMethod=lambda a, b: None)
     ctr.show()
     app.exec_()
 

--- a/guis/panel/heater/launch_sa_heater.py
+++ b/guis/panel/heater/launch_sa_heater.py
@@ -1,3 +1,8 @@
+# ===============================================================================
+# Launch the paas heater gui, which controls the heater arduino box.
+# Save the data to a csv file in
+# data/Panel\ Data/external_gui_data/heat_control_data
+# ===============================================================================
 from guis.panel.heater.PanelHeater import HeatControl
 from guis.common.panguilogger import SetupPANGUILogger
 from PyQt5.QtWidgets import QApplication

--- a/guis/panel/heater/load_heat_csv_into_db.py
+++ b/guis/panel/heater/load_heat_csv_into_db.py
@@ -4,6 +4,7 @@
 
 import sqlalchemy as sqla  # for interacting with db
 import sys, csv
+from pathlib import Path
 from datetime import datetime as dt
 
 from guis.common.getresources import GetProjectPaths, GetLocalDatabasePath
@@ -51,7 +52,7 @@ def run(panel, process, data_file):
 
     print(f"Writing data from file {data_file}")
     try:
-        assert data_file.is_file()
+        assert Path(data_file).is_file()
     except AssertionError:
         print(f"Data file {data_file} not found!")
 
@@ -103,3 +104,7 @@ def run(panel, process, data_file):
                     "The data is now in the local database. To send it to the"
                     "network (and see it in DBV) trigger an automerge."
                 )
+
+
+if __name__ == "__main__":
+    run(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/guis/panel/heater/simple_monitor.bat
+++ b/guis/panel/heater/simple_monitor.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
 cls
 CD C:\Users\mu2e\Desktop\Production
-python -m guis.panel.heater 1
+python -m guis.panel.heater.simple_monitor
 pause

--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -5452,62 +5452,10 @@ class panelGUI(QMainWindow):
             shell=True,
             cwd=root_dir,
         )
-        # os.system(f"start cmd.exe @cmd python -m guis.panel.heater {panelID}")
-        # os.system(f"start /B start cmd.exe @cmd python -m guis.panel.heater {panelID}")
-        # os.system(f"start cmd /c python -m guis.panel.heater {panelID}")
-        # subprocess.call(
-        #    f"start /wait python -m guis.panel.heater {panelID}",
-        #    shell=True,
-        #    cwd=root_dir,
-        # )
-        # subprocess.call(
-        #    f"start cmd /K python -m guis.panel.heater {panelID}",
-        #    shell=True,
-        #    cwd=root_dir,
-        # )
-        # subprocess.call(f"python -m guis.panel.heater {panelID}", creationflags=subprocess.CREATE_NEW_CONSOLE, cwd=root_dir, shell=True)
-        # print("HERE")
-        # os.system("cmd.exe")
-        # subprocess.call("start /wait python -m guis.panel.heater PAUSE", cwd=root_dir, shell=True )
-        # subprocess.call("start /wait ", cwd=root_dir, shell=True )
-        """
-        else:  # old method: launch heater internally, save directly to the db
-            if self.checkDevice() == True:  # if no device connected,
-                return  # return from this function
-
-            if self.panelHeaterWindow is not None:  # if a window already exists
-                buttonReply = QMessageBox.question(  # prompt user, ask if they want to kill old window
-                    self,
-                    "Panel Heater Window",
-                    "If a panel heater window is already open, launching a new one will close the old one.  Continue?",
-                    QMessageBox.Yes | QMessageBox.Cancel,  # button options
-                    QMessageBox.Cancel,
-                )  # default selection
-                if buttonReply == QMessageBox.Yes:
-                    self.panelHeaterWindow = None  # close the window!
-                else:
-                    return  # don't close the window!  keep it safe by returning!
-
-            if self.panelHeaterWindow == None:  # if no window yet,
-                # get the current panel ID (one of the inputs will have text, the others will have none)
-                panelID = f"{self.ui.panelInput6.text()}{self.ui.panelInput2.text()}{self.ui.panelInput1.text()}"
-                self.panelHeaterWindow = HeatControl(
-                    port="GUI",
-                    panel=panelID,
-                    saveMethod=(
-                        lambda temp_paas_a, temp_paas_bc: (
-                            self.DP.savePanelTempMeasurement(temp_paas_a, temp_paas_bc)
-                        )
-                    ),
-                )
-                self.panelHeaterWindow.show()
-                logger.info("Heater launched")
-        """
 
     # creates HV measurements gui window
     # uses highVoltageGUI from GUIs/current/tension_devices/hv_gui/hvGUImain
     def hvMeasurementsPopup(self):
-
         if self.hvMeasurementsWindow is not None:  # if a window already exists
             buttonReply = QMessageBox.question(  # prompt user, ask if they want to kill old window
                 self,

--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -5445,44 +5445,45 @@ class panelGUI(QMainWindow):
     # the (local) database.
     #
     # Uses HeatControl from guis/panel/heater/PanelHeater.py.
-    def panelHeaterPopup(self):
-        root_dir = pkg_resources.read_text(resources, "rootDirectory.txt")
-        subprocess.call(
-            "start /wait python -m guis.panel.heater", shell=True, cwd=root_dir
-        )
-
-        """
-        if self.checkDevice() == True:  # if no device connected,
-            return  # return from this function
-
-        if self.panelHeaterWindow is not None:  # if a window already exists
-            buttonReply = QMessageBox.question(  # prompt user, ask if they want to kill old window
-                self,
-                "Panel Heater Window",
-                "If a panel heater window is already open, launching a new one will close the old one.  Continue?",
-                QMessageBox.Yes | QMessageBox.Cancel,  # button options
-                QMessageBox.Cancel,
-            )  # default selection
-            if buttonReply == QMessageBox.Yes:
-                self.panelHeaterWindow = None  # close the window!
-            else:
-                return  # don't close the window!  keep it safe by returning!
-
-        if self.panelHeaterWindow == None:  # if no window yet,
-            # get the current panel ID (one of the inputs will have text, the others will have none)
-            panelID = f"{self.ui.panelInput6.text()}{self.ui.panelInput2.text()}{self.ui.panelInput1.text()}"
-            self.panelHeaterWindow = HeatControl(
-                port="GUI",
-                panel=panelID,
-                saveMethod=(
-                    lambda temp_paas_a, temp_paas_bc: (
-                        self.DP.savePanelTempMeasurement(temp_paas_a, temp_paas_bc)
-                    )
-                ),
+    def panelHeaterPopup(self, launch_externally=True):
+        if launch_externally:
+            root_dir = pkg_resources.read_text(resources, "rootDirectory.txt")
+            subprocess.call(
+                f"start /wait python -m guis.panel.heater.launch_sa_heater {panelID}",
+                shell=True,
+                cwd=root_dir,
             )
-            self.panelHeaterWindow.show()
-            logger.info("Heater launched")
-        """
+        else:  # old method: launch heater internally, save directly to the db
+            if self.checkDevice() == True:  # if no device connected,
+                return  # return from this function
+
+            if self.panelHeaterWindow is not None:  # if a window already exists
+                buttonReply = QMessageBox.question(  # prompt user, ask if they want to kill old window
+                    self,
+                    "Panel Heater Window",
+                    "If a panel heater window is already open, launching a new one will close the old one.  Continue?",
+                    QMessageBox.Yes | QMessageBox.Cancel,  # button options
+                    QMessageBox.Cancel,
+                )  # default selection
+                if buttonReply == QMessageBox.Yes:
+                    self.panelHeaterWindow = None  # close the window!
+                else:
+                    return  # don't close the window!  keep it safe by returning!
+
+            if self.panelHeaterWindow == None:  # if no window yet,
+                # get the current panel ID (one of the inputs will have text, the others will have none)
+                panelID = f"{self.ui.panelInput6.text()}{self.ui.panelInput2.text()}{self.ui.panelInput1.text()}"
+                self.panelHeaterWindow = HeatControl(
+                    port="GUI",
+                    panel=panelID,
+                    saveMethod=(
+                        lambda temp_paas_a, temp_paas_bc: (
+                            self.DP.savePanelTempMeasurement(temp_paas_a, temp_paas_bc)
+                        )
+                    ),
+                )
+                self.panelHeaterWindow.show()
+                logger.info("Heater launched")
 
     # creates HV measurements gui window
     # uses highVoltageGUI from GUIs/current/tension_devices/hv_gui/hvGUImain

--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -5445,14 +5445,32 @@ class panelGUI(QMainWindow):
     # the (local) database.
     #
     # Uses HeatControl from guis/panel/heater/PanelHeater.py.
-    def panelHeaterPopup(self, launch_externally=True):
-        if launch_externally:
-            root_dir = pkg_resources.read_text(resources, "rootDirectory.txt")
-            subprocess.call(
-                f"start /wait python -m guis.panel.heater.launch_sa_heater {panelID}",
-                shell=True,
-                cwd=root_dir,
-            )
+    def panelHeaterPopup(self):
+        root_dir = pkg_resources.read_text(resources, "rootDirectory.txt")
+        subprocess.call(
+            f"start /wait python -m guis.panel.heater {self.getCurrentPanel()} PAUSE",
+            shell=True,
+            cwd=root_dir,
+        )
+        # os.system(f"start cmd.exe @cmd python -m guis.panel.heater {panelID}")
+        # os.system(f"start /B start cmd.exe @cmd python -m guis.panel.heater {panelID}")
+        # os.system(f"start cmd /c python -m guis.panel.heater {panelID}")
+        # subprocess.call(
+        #    f"start /wait python -m guis.panel.heater {panelID}",
+        #    shell=True,
+        #    cwd=root_dir,
+        # )
+        # subprocess.call(
+        #    f"start cmd /K python -m guis.panel.heater {panelID}",
+        #    shell=True,
+        #    cwd=root_dir,
+        # )
+        # subprocess.call(f"python -m guis.panel.heater {panelID}", creationflags=subprocess.CREATE_NEW_CONSOLE, cwd=root_dir, shell=True)
+        # print("HERE")
+        # os.system("cmd.exe")
+        # subprocess.call("start /wait python -m guis.panel.heater PAUSE", cwd=root_dir, shell=True )
+        # subprocess.call("start /wait ", cwd=root_dir, shell=True )
+        """
         else:  # old method: launch heater internally, save directly to the db
             if self.checkDevice() == True:  # if no device connected,
                 return  # return from this function
@@ -5484,6 +5502,7 @@ class panelGUI(QMainWindow):
                 )
                 self.panelHeaterWindow.show()
                 logger.info("Heater launched")
+        """
 
     # creates HV measurements gui window
     # uses highVoltageGUI from GUIs/current/tension_devices/hv_gui/hvGUImain

--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -5437,10 +5437,21 @@ class panelGUI(QMainWindow):
             # log launch
             logger.info("Tensionbox launched")
 
-    # creates panel heater gui window
-    # uses HeatControl from GUIs/current/tension_devices/panel_heater/PanelHeater.py
+    # Creates a new terminal window and runs the panel heater as a standalone
+    # program.
+    #
+    # This call to the heater will save data livetime to a csv file and when
+    # the End Data Collection button is pressed, the data will be loaded into
+    # the (local) database.
+    #
+    # Uses HeatControl from guis/panel/heater/PanelHeater.py.
     def panelHeaterPopup(self):
+        root_dir = pkg_resources.read_text(resources, "rootDirectory.txt")
+        subprocess.call(
+            "start /wait python -m guis.panel.heater", shell=True, cwd=root_dir
+        )
 
+        """
         if self.checkDevice() == True:  # if no device connected,
             return  # return from this function
 
@@ -5471,6 +5482,7 @@ class panelGUI(QMainWindow):
             )
             self.panelHeaterWindow.show()
             logger.info("Heater launched")
+        """
 
     # creates HV measurements gui window
     # uses highVoltageGUI from GUIs/current/tension_devices/hv_gui/hvGUImain

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,0 +1,5 @@
+import tests.load_heat_csv_into_db as loader
+
+
+if __name__ == "__main__":
+    loader.run()

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,5 +1,6 @@
 import tests.load_heat_csv_into_db as loader
+from sys import argv
 
 
 if __name__ == "__main__":
-    loader.run()
+    loader.run(argv[1], argv[2])

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,6 +1,0 @@
-import tests.load_heat_csv_into_db as loader
-from sys import argv
-
-
-if __name__ == "__main__":
-    loader.run(argv[1], argv[2])

--- a/tests/load_heat_csv_into_db.py
+++ b/tests/load_heat_csv_into_db.py
@@ -4,6 +4,7 @@
 
 import sqlalchemy as sqla  # for interacting with db
 import sys, csv
+from datetime import datetime as dt
 
 from guis.common.getresources import GetProjectPaths, GetLocalDatabasePath
 
@@ -39,7 +40,7 @@ def WriteSingleMeasurementToDB(connection, pid, t1, t2, timestamp):
     # con.commit()
 
 
-def run():
+def run(panel=109, process=1):
     database = GetLocalDatabasePath()
 
     print(f"Writing to {database}")
@@ -51,14 +52,20 @@ def run():
     engine = sqla.create_engine("sqlite:///" + database)  # create engine
 
     with engine.connect() as connection:
-        panel = 109
-        process = 1
-
-        pid = GetProcedureID(connection, panel, process)
+        pid = GetProcedureID(connection, int(panel), int(process))
 
         print(f"Found procedure ID for panel {panel} process {process}: {pid}")
 
-        data_file = "MN109_2021-04-02.csv"
+        # data_file = "MN109_2021-04-02.csv"
+        data_file = (
+            "MN"
+            + str(panel)
+            + "_"
+            + dt.now().strftime("%Y-%m-%d")
+            + "_pro"
+            + str(process)
+            + ".csv"
+        )
 
         data_file = GetProjectPaths()["heatdata"] / data_file
 
@@ -70,7 +77,7 @@ def run():
             print(f"data file {data_file} not found!")
 
         query = """
-        INSERT INTO panel_heat (procedure, temp_paas_a, temp_paas_bc, timestamp)
+        INSERT OR IGNORE INTO panel_heat (procedure, temp_paas_a, temp_paas_bc, timestamp)
         VALUES (?, ?, ?, ?);
         """
 

--- a/tests/load_heat_csv_into_db.py
+++ b/tests/load_heat_csv_into_db.py
@@ -1,0 +1,92 @@
+import sqlalchemy as sqla  # for interacting with db
+import sys
+
+kPROCESSES = list(range(1, 8))
+
+try:
+    import importlib.resources as pkg_resources
+except ImportError:
+    # Try backported to PY<37 `importlib_resources`.
+    import importlib_resources as pkg_resources
+import data, resources
+
+
+def LoadLocalDatabasePath():
+    with pkg_resources.path(data, "database.db") as p:
+        return str(p.resolve())
+
+
+def GetProcedureID(connection, panel, process):
+    assert isinstance(panel, int) and panel <= 999
+    assert process in kPROCESSES
+    query = f"""
+    SELECT procedure.id from procedure
+    INNER JOIN straw_location on procedure.straw_location = straw_location.id
+    WHERE straw_location.location_type = "MN" 
+    AND straw_location.number = {panel} 
+    AND procedure.station = "pan{process}"
+    """
+    # print(query)
+    result = connection.execute(query)
+    result = result.fetchall()[0][0]
+    return result
+
+
+def WriteTempsToDB(connection, pid, t1, t2, timestamp):
+    query = f"""
+    INSERT INTO panel_heat (procedure, temp_paas_a, temp_paas_bc, timestamp)
+    VALUES ('{pid}','{t1}','{t2}','{timestamp}')
+    """
+    print(query)
+    connection.execute(query)
+
+    # to_db = [(i['col1'], i['col2']) for i in dr]
+    # cur.executemany("INSERT INTO t (col1, col2) VALUES (?, ?);", to_db)
+    # con.commit()
+
+
+def run():
+    database = LoadLocalDatabasePath()
+
+    print(f"Writing to {database}")
+
+    db_check = input("PRESS <ENTER> TO VERIFY THIS DATABASE, ELSE PRESS CTRL-C\n")
+    if db_check:
+        sys.exit("DB not verified, exiting")
+
+    engine = sqla.create_engine("sqlite:///" + database)  # create engine
+
+    connection = engine.connect()  # connect engine with DB
+
+    pid = GetProcedureID(connection, panel=52, process=1)
+
+    WriteTempsToDB(connection, pid, t1=888, t2=888, timestamp=1598066667)
+
+    connection.close()
+
+
+"""
+import csv, sqlite3
+
+con = sqlite3.connect(":memory:") # change to 'sqlite:///your_filename.db'
+cur = con.cursor()
+cur.execute("CREATE TABLE t (col1, col2);") # use your column names here
+
+with open('data.csv','r') as fin: # `with` statement available in 2.5+
+        # csv.DictReader uses first line in file for column headings by default
+            dr = csv.DictReader(fin) # comma is default delimiter
+                to_db = [(i['col1'], i['col2']) for i in dr]
+
+                cur.executemany("INSERT INTO t (col1, col2) VALUES (?, ?);", to_db)
+                con.commit()
+                con.close()
+
+panelIDQuery = (
+    # select panel ids
+    sqla.select([self.panelsTable.columns.id])
+    # where number = user input panel number
+    .where(self.panelsTable.columns.number == self.data.humanID)
+    # and where location type = MN (we don't want LPALs)
+    .where(self.panelsTable.columns.location_type == "MN")
+)
+"""

--- a/tests/load_heat_csv_into_db.py
+++ b/tests/load_heat_csv_into_db.py
@@ -40,10 +40,10 @@ def WriteSingleMeasurementToDB(connection, pid, t1, t2, timestamp):
     # con.commit()
 
 
-def run(panel=109, process=1):
+def run(panel, process):
     database = GetLocalDatabasePath()
 
-    print(f"Writing to {database}")
+    print(f"Writing to heat data to local database {database}")
 
     db_check = input("PRESS <ENTER> TO VERIFY THIS DATABASE, ELSE PRESS CTRL-C\n")
     if db_check:

--- a/tests/load_heat_csv_into_db.py
+++ b/tests/load_heat_csv_into_db.py
@@ -1,26 +1,13 @@
-#===============================================================================
-# Load a heat CSV file into the database
-#===============================================================================
+# ===============================================================================
+# Load a heat CSV file into the local database
+# ===============================================================================
 
 import sqlalchemy as sqla  # for interacting with db
 import sys, csv
 
+from guis.common.getresources import GetProjectPaths, GetLocalDatabasePath
+
 kPROCESSES = list(range(1, 8))
-
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
-    import importlib_resources as pkg_resources
-import data, resources
-
-from guis.common.getresources import GetProjectPaths
-
-
-def LoadLocalDatabasePath():
-    with pkg_resources.path(data, "database.db") as p:
-        return str(p.resolve())
-
 
 # Given a panel and process, access the DB to get the procedure ID
 def GetProcedureID(connection, panel, process):
@@ -38,7 +25,8 @@ def GetProcedureID(connection, panel, process):
     return result
 
 
-def WriteTempsToDB(connection, pid, t1, t2, timestamp):
+# Deprecated
+def WriteSingleMeasurementToDB(connection, pid, t1, t2, timestamp):
     query = f"""
     INSERT INTO panel_heat (procedure, temp_paas_a, temp_paas_bc, timestamp)
     VALUES ('{pid}','{t1}','{t2}','{timestamp}')
@@ -52,7 +40,7 @@ def WriteTempsToDB(connection, pid, t1, t2, timestamp):
 
 
 def run():
-    database = LoadLocalDatabasePath()
+    database = GetLocalDatabasePath()
 
     print(f"Writing to {database}")
 
@@ -60,55 +48,60 @@ def run():
     if db_check:
         sys.exit("DB not verified, exiting")
 
-
     engine = sqla.create_engine("sqlite:///" + database)  # create engine
 
     with engine.connect() as connection:
+        panel = 109
+        process = 1
 
-        pid = GetProcedureID(connection, panel=100, process=1)
+        pid = GetProcedureID(connection, panel, process)
 
-        data_file = GetProjectPaths()["heatdata"] / "MN142_2021-07-01.csv"
+        print(f"Found procedure ID for panel {panel} process {process}: {pid}")
 
-        with open (data_file,'r') as f:
+        data_file = "MN109_2021-04-02.csv"
+
+        data_file = GetProjectPaths()["heatdata"] / data_file
+
+        print(f"Reading data file {data_file}")
+
+        try:
+            assert data_file.is_file()
+        except AssertionError:
+            print(f"data file {data_file} not found!")
+
+        query = """
+        INSERT INTO panel_heat (procedure, temp_paas_a, temp_paas_bc, timestamp)
+        VALUES (?, ?, ?, ?);
+        """
+
+        with open(data_file, "r") as f:
             dr = csv.DictReader(f)
 
             # an entry of dr looks like:
             # OrderedDict([('Date', '2021-07-02_073223'), ('PAASA_Temp[C]', '-242.02'), ('2ndPAAS_Temp[C]', '-99.00'), ('Epoc', '1625229143.7965412')])
-            to_db = [(pid, i['PAASA_Temp[C]'], i['2ndPAAS_Temp[C]'], int(float(i['Epoc']))) for i in dr]
+            to_db = [
+                (pid, i["PAASA_Temp[C]"], i["2ndPAAS_Temp[C]"], int(float(i["Epoc"])))
+                for i in dr
+            ]
 
-            to_db = to_db[:5]
+            # to_db = to_db[:5]
 
-            connection.executemany("INSERT INTO panel_heat (procedure, temp_paas_a, temp_paas_b, timestamp) VALUES (?, ?, ?, ?);", to_db)
-
-            #for i in to_db:
-            #    print(i)
-        #WriteTempsToDB(connection, pid, t1=888, t2=888, timestamp=1598066667)
-
-        #to_db = [for i in dr]
-
-
-"""
-import csv, sqlite3
-
-con = sqlite3.connect(":memory:") # change to 'sqlite:///your_filename.db'
-cur = con.cursor()
-cur.execute("CREATE TABLE t (col1, col2);") # use your column names here
-
-with open('data.csv','r') as fin: # `with` statement available in 2.5+
-        # csv.DictReader uses first line in file for column headings by default
-            dr = csv.DictReader(fin) # comma is default delimiter
-                to_db = [(i['col1'], i['col2']) for i in dr]
-
-                cur.executemany("INSERT INTO t (col1, col2) VALUES (?, ?);", to_db)
-                con.commit()
-                con.close()
-
-panelIDQuery = (
-    # select panel ids
-    sqla.select([self.panelsTable.columns.id])
-    # where number = user input panel number
-    .where(self.panelsTable.columns.number == self.data.humanID)
-    # and where location type = MN (we don't want LPALs)
-    .where(self.panelsTable.columns.location_type == "MN")
-)
-"""
+            try:
+                r_set = connection.execute(query, to_db)
+            except sqla.exc.OperationalError as e:
+                print(e)
+                error = str(e.__dict__["orig"])
+                print(error)
+            except sqla.exc.IntegrityError as e:
+                # print(e)
+                error = str(e.__dict__["orig"])
+                print(error)
+                print(
+                    "ERROR: At least one datapoint in this CSV file already exists in the DB."
+                )
+                print("ERROR: Was this CSV file already loaded?")
+                print("ERROR: Tell Ben if this is unexpected or otherwise a problem.")
+            else:
+                print(
+                    f"Loaded {r_set.rowcount} heat data points into the local DB for panel {panel} process {process}"
+                )


### PR DESCRIPTION
Launching the heater from a separate thread within pangui allows us to (easily) save directly to the database.

However, I've concluded that this is more trouble than it's worth. So many troubles related to the network, locked databases, non-physical data points related to automerge. Many of them documented https://trello.com/c/RmRQyvw3.

In the new system: launch the heater as a process completely separate from pangui. Save data to a text file, and upon completion of data taking, upload the data to the database.

This involved adding a uniqueness constraint to (procedure, timestamp) pairs in the `panel_heat` table.