### PR TITLE
Panel resist arduino search

### DIFF
--- a/guis/panel/resistance/run_test/run_test.py
+++ b/guis/panel/resistance/run_test/run_test.py
@@ -22,8 +22,8 @@ def GetSerialPort():
     serialport = None
     avail_ports = serial.tools.list_ports.comports()
     for port, desc, hwid in sorted(avail_ports):
-        # print("{}: {} [{}]".format(port, desc, hwid))
-        if ("USB" in desc or "USB" in hwid) and ("Arduino" in desc or "Arduino" in hwid):
+        print("{}: {} [{}]".format(port, desc, hwid))
+        if ("USB" in desc or "USB" in hwid):
             try:
                 serialport = serial.Serial(
                     port=port, baudrate=baudrate, timeout=timeout

--- a/guis/panel/resistance/run_test/run_test.py
+++ b/guis/panel/resistance/run_test/run_test.py
@@ -22,8 +22,17 @@ def GetSerialPort():
     serialport = None
     avail_ports = serial.tools.list_ports.comports()
     for port, desc, hwid in sorted(avail_ports):
-        print("{}: {} [{}]".format(port, desc, hwid))
-        if ("USB" in desc or "USB" in hwid):
+        # print("{}: {} [{}]".format(port, desc, hwid))
+        if "USB" in desc or "USB" in hwid:
+
+            # The QC computer uses a different arduino than the others and/or
+            # the resistance arduino box is named differently on this computer
+            # and/or confusion is caused with the temp/humid device
+            if "15" in os.getenv("USERDOMAIN") and not (
+                "Arduino" in desc or "Arduino" in hwid
+            ):
+                continue
+
             try:
                 serialport = serial.Serial(
                     port=port, baudrate=baudrate, timeout=timeout


### PR DESCRIPTION
Problem: computer 15 couldn't find the resistance arduino box device.

The way the device search goes is that it looks for a device with the keyword "USB" in it.

Computer 15 always has the temp/humidity device plugged into it, and this device was being found before the resist arduino.

To fix this, I required that the keyword "arduino" also be found in the device description.

Well this fix worked for computer 15/that specific resistance arduino, BUT it broke all the other computers/resistance arduinos. I'm not sure if the other arduinos are described differently inherently (without the keyword "arduino") OR whether the computer names them differently or what.

So the current solution is to treat computer 15 differently -- having it look for "arduino", but not having the other computers require that keyword.

The _real_ solution is probably to search among the device ID numbers for the resist boxes and use those. I don't have all of them in front of me, so this is the temporary solution.