### PR TITLE
Add straw tensions to TB live display

### DIFF
--- a/guis/panel/tensionbox/X0117d.py
+++ b/guis/panel/tensionbox/X0117d.py
@@ -37,13 +37,15 @@ class DataCanvas(FigureCanvas):
         self.axes.set_xlabel(xlabel)
         self.axes.set_ylabel(ylabel)
         self.axes.set_xlim(-2, 96)
-        self.axes.set_ylim(-2, 100)
+        self.axes.set_ylim(bottom=-2, top=200)
+        # self.axes.autoscale(enable=True, axis='y')
         box = self.axes.get_position()
         if ylabel2:
-            self.axes2 = self.axes.twinx()
-            self.axes2.set_ylabel(ylabel2)
-            self.axes2.yaxis.label.set_color("r")
-            self.axes2.set_ylim(-2, 800)
+            self.rhs_axes = self.axes.twinx()
+            self.rhs_axes.set_ylabel(ylabel2)
+            self.rhs_axes.set_ylim(bottom=-2, top=700)
+            self.rhs_axes.yaxis.label.set_color("r")
+            # self.rhs_axes.autoscale(enable=True, axis='y')
             self.axes.set_position(
                 [box.x0, box.y0 + box.height * 0.05, box.width * 0.95, box.height]
             )
@@ -52,12 +54,18 @@ class DataCanvas(FigureCanvas):
                 [box.x0, box.y0 + box.height * 0.03, box.width * 1.1, box.height * 1.1]
             )
 
-    def read_data(self, data, is_straw=False):
-        if is_straw:
-            if self.axes2:
-                self.axes2.plot(data[:, 0], data[:, 1], "g.", color="r")
+    def read_data(self, data, is_rhs=False):
+        if is_rhs:
+            if self.rhs_axes:
+                self.rhs_axes.plot(data[:, 0], data[:, 1], "g.", color="r")
+                # data_range = np.ptp(data[:,1])
+                # self.rhs_axes.set_ylim(bottom=min(min(data[:,1])-data_range*0.9,0), top=max(data[:,1])*1.1)
+                # self.rhs_axes.relim()
         else:
-            self.axes.plot(data[:, 0], data[:, 1], "g.")
+            self.axes.plot(data[:, 0], data[:, 1], "g.", color="k")
+            # data_range = np.ptp(data[:,1])
+            # self.axes.set_ylim(bottom=min(data[:,1])*0.9, top=max(data[:,1])+data_range*1.1)
+            # self.axes.relim()
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
 

--- a/guis/panel/tensionbox/X0117d.py
+++ b/guis/panel/tensionbox/X0117d.py
@@ -24,6 +24,7 @@ class DataCanvas(FigureCanvas):
         dpi=100,
         xlabel="xlabel",
         ylabel="ylabel",
+        ylabel2=None,
     ):
         self.fig = Figure(figsize=(width, height), dpi=dpi)
         self.axes = self.fig.add_subplot(111)
@@ -33,17 +34,30 @@ class DataCanvas(FigureCanvas):
         FigureCanvas.setSizePolicy(self, QSizePolicy.Expanding, QSizePolicy.Expanding)
         FigureCanvas.updateGeometry(self)
         self.axes.grid(True)
-        self.axes.set_ylabel(ylabel)
         self.axes.set_xlabel(xlabel)
+        self.axes.set_ylabel(ylabel)
         self.axes.set_xlim(-2, 96)
         self.axes.set_ylim(-2, 100)
         box = self.axes.get_position()
-        self.axes.set_position(
-            [box.x0, box.y0 + box.height * 0.03, box.width * 1.1, box.height * 1.1]
-        )
+        if ylabel2:
+            self.axes2 = self.axes.twinx()
+            self.axes2.set_ylabel(ylabel2)
+            self.axes2.yaxis.label.set_color("r")
+            self.axes2.set_ylim(-2, 800)
+            self.axes.set_position(
+                [box.x0, box.y0 + box.height * 0.05, box.width * 0.95, box.height]
+            )
+        else:
+            self.axes.set_position(
+                [box.x0, box.y0 + box.height * 0.03, box.width * 1.1, box.height * 1.1]
+            )
 
-    def read_data(self, data):
-        self.axes.plot(data[:, 0], data[:, 1], "g.")
+    def read_data(self, data, is_straw=False):
+        if is_straw:
+            if self.axes2:
+                self.axes2.plot(data[:, 0], data[:, 1], "g.", color="r")
+        else:
+            self.axes.plot(data[:, 0], data[:, 1], "g.")
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
 


### PR DESCRIPTION
Modify canvas object to accept optional second RHS axis.

And modify TB to also plot straw tensions.

Pretty gnarly hack. Auto-axis adjust would probably be good.

Canvas object shouldn't have args referring to 'straws' or whatever.

But it does seem to be working.