### PR TITLE
Save straw resistance measurements to the DB

### DIFF
--- a/guis/common/db_classes/measurements_straw.py
+++ b/guis/common/db_classes/measurements_straw.py
@@ -21,37 +21,6 @@ from datetime import datetime
 
 
 """
-class Resistance(BASE, OBJECT):
-    __tablename__ = 'measurement_ohms'
-    id = Column(Integer, primary_key=True)
-    procedure = Column(Integer, ForeignKey('procedure.id'))
-    straw = Column(Integer, ForeignKey('straw.id'))
-    inside_inside_resistance = Column(REAL)
-    inside_inside_method = Column(String)
-    inside_outside_resistance = Column(REAL)
-    inside_outside_method = Column(String)
-    outside_inside_resistance = Column(REAL)
-    outside_inside_method = Column(String)
-    outside_outside_resistance = Column(REAL)
-    outside_outside_method = Column(String)
-    evaluation = Column(BOOLEAN)
-    timestamp= Column(Integer, default=int(datetime.now().timestamp()))
-
-    def __init__(self, procedure, straw, inside_inside_resistance,inside_inside_method,inside_outside_resistance,inside_outside_method,outside_inside_resistance,\
-         outside_inside_method, outside_outside_resistance, outside_outside_method, evaluation):
-        self.procedure = procedure
-        self.straw = straw
-        self.inside_inside_resistance = inside_inside_resistance
-        self.inside_inside_method = inside_inside_method
-        self.inside_outside_resistance = inside_outside_resistance
-        self.inside_outside_method = inside_outside_method
-        self.outside_inside_resistance = outside_inside_resistance
-        self.outside_inside_method = outside_inside_method
-        self.outside_outside_resistance = outside_outside_resistance
-        self.outside_outside_method = outside_outside_method
-        self.evaluation = evaluation
-        self.commit()
-        
 class CO2(BASE, OBJECT):
     __tablename__ = 'measurement_co2'
     id = Column(Integer, primary_key=True)

--- a/guis/common/db_classes/procedures_panel.py
+++ b/guis/common/db_classes/procedures_panel.py
@@ -1,5 +1,5 @@
 ################################################################################
-# INDIVIDUAL PROCESS DATA TABLES
+# Panel Process Metadata Classes/Tables
 #
 # These classes define the procedure_details_panX tables. These tables hold
 # info specific to each process. Epoxy batch numbers and timers, process-wide

--- a/guis/common/db_classes/procedures_straw.py
+++ b/guis/common/db_classes/procedures_straw.py
@@ -34,7 +34,6 @@ class Prep(StrawProcedure):
         id = Column(Integer, primary_key=True)
         procedure = Column(Integer, ForeignKey("procedure.id"))
         straw = Column(Integer, ForeignKey("straw.id"))
-        # straw = Column(Integer)
         paper_pull_grade = Column(CHAR)
         evaluation = Column(BOOLEAN)
         timestamp = Column(Integer, default=int(datetime.now().timestamp()))
@@ -64,6 +63,49 @@ class Resistance(StrawProcedure):
             station.id == "ohms"
         ), f"Error. Tried to construct ohms procedure for a station '{station.id}' not 'ohms'."
         super().__init__(station, straw_location, create_key)
+
+    class StrawResistanceMeasurement(BASE, OBJECT):
+        __tablename__ = "measurement_ohms"
+        id = Column(Integer, primary_key=True)
+        procedure = Column(Integer, ForeignKey("procedure.id"))
+        straw = Column(Integer, ForeignKey("straw.id"))
+        inside_inside_resistance = Column(REAL)
+        inside_inside_method = Column(String)
+        inside_outside_resistance = Column(REAL)
+        inside_outside_method = Column(String)
+        outside_inside_resistance = Column(REAL)
+        outside_inside_method = Column(String)
+        outside_outside_resistance = Column(REAL)
+        outside_outside_method = Column(String)
+        evaluation = Column(BOOLEAN)
+        timestamp = Column(Integer, default=int(datetime.now().timestamp()))
+
+        def __init__(
+            self,
+            procedure,
+            straw,
+            inside_inside_resistance,
+            inside_inside_method,
+            inside_outside_resistance,
+            inside_outside_method,
+            outside_inside_resistance,
+            outside_inside_method,
+            outside_outside_resistance,
+            outside_outside_method,
+            evaluation,
+        ):
+            self.procedure = procedure
+            self.straw = straw
+            self.inside_inside_resistance = inside_inside_resistance
+            self.inside_inside_method = inside_inside_method
+            self.inside_outside_resistance = inside_outside_resistance
+            self.inside_outside_method = inside_outside_method
+            self.outside_inside_resistance = outside_inside_resistance
+            self.outside_inside_method = outside_inside_method
+            self.outside_outside_resistance = outside_outside_resistance
+            self.outside_outside_method = outside_outside_method
+            self.evaluation = evaluation
+            self.commit()
 
 
 """

--- a/guis/common/db_classes/procedures_straw.py
+++ b/guis/common/db_classes/procedures_straw.py
@@ -26,7 +26,7 @@ class Prep(StrawProcedure):
     def __init__(self, station, straw_location, create_key):
         assert (
             station.id == "prep"
-        ), f"Error. Tried to construct prep preocedure for a station '{station.id}' not 'prep'."
+        ), f"Error. Tried to construct prep procedure for a station '{station.id}' not 'prep'."
         super().__init__(station, straw_location, create_key)
 
     class StrawPrepMeasurement(BASE, OBJECT):
@@ -52,6 +52,18 @@ class Prep(StrawProcedure):
             paper_pull_grade=paper_pull_grade,
             evaluation=evaluation,
         ).commit()
+
+
+class Resistance(StrawProcedure):
+    __mapper_args__ = {
+        "polymorphic_identity": "ohms"
+    }  # foreign link to which station.id
+
+    def __init__(self, station, straw_location, create_key):
+        assert (
+            station.id == "ohms"
+        ), f"Error. Tried to construct ohms procedure for a station '{station.id}' not 'ohms'."
+        super().__init__(station, straw_location, create_key)
 
 
 """

--- a/guis/straw/prep/PrepGUI.py
+++ b/guis/straw/prep/PrepGUI.py
@@ -629,12 +629,12 @@ class Prep(QMainWindow):
         with open(pfile, "w+") as file:
             header = "Time Stamp, Task, 24 Straw Names/Statuses, Workers"
             header += ", ***" + str(self.strawCount) + " straws initially on pallet***"
+            header += f" {self.palletID}"
             header += "\n"
             file.write(header)
 
             # Record Session Data
             file.write(datetime.now().strftime("%Y-%m-%d_%H:%M") + ",")
-            file.write(self.palletID + ",")
             file.write(self.stationID + ",")
 
             # Record each straw and whether it passes/fails

--- a/guis/straw/prep/PrepGUI.py
+++ b/guis/straw/prep/PrepGUI.py
@@ -721,11 +721,12 @@ class Prep(QMainWindow):
 
         elif label == "Log Out":
             portalNum = int(btn.objectName().strip("portal")) - 1
-            self.justLogOut = self.Current_workers[portalNum].text()
-            self.sessionWorkers.remove(self.Current_workers[portalNum].text())
-            print("Goodbye " + self.Current_workers[portalNum].text() + " :(")
-            Current_worker = ""
-            self.Current_workers[portalNum].setText(Current_worker)
+            worker = self.Current_workers[portalNum].text()
+            self.justLogOut = worker
+            self.sessionWorkers.remove(worker)
+            self.DP.saveLogout(worker)
+            print("Goodbye " + worker + " :(")
+            self.Current_workers[portalNum].setText("")
             btn.setText("Log In")
 
         # Recheck credentials

--- a/guis/straw/prep/PrepGUI.py
+++ b/guis/straw/prep/PrepGUI.py
@@ -1,12 +1,17 @@
-#
-# PrepGUI.py
+################################################################################
 #
 # Straw Prep (Paper Pull) GUI
-# Straw Lab GUIs 20.
 #
-# Author: Joe Dill
-# email: dillx031@umn.edu
+# First step in straw processing in which straw ids/barcodes are assigned to
+# straws, they enter the database for the first time, and they are assigned to
+# a cutting pallet (which also enters the database for the first time).
 #
+# After getting entered into the database, their paper is removed, quality
+# graded, and data saved.
+#
+# Next step: resistance test
+#
+################################################################################
 from guis.common.panguilogger import SetupPANGUILogger
 
 logger = SetupPANGUILogger("root", "StrawPrep")
@@ -183,7 +188,7 @@ class Prep(QMainWindow):
     # 2. finish paper pull button: checkPPGData
     # 3. finish button: saveData
     ############################################################################
-    # Start button: get prelim data, then enable ppg fields
+    # 1. Start button: get prelim data, then enable ppg fields
     def beginProcess(self):
         # collect panel prelim/metadata
         if not self.PalletInfoCollected:
@@ -516,7 +521,7 @@ class Prep(QMainWindow):
             self.input_batchBarcode[0].setText("NO STRAW")
             self.dataValidity["Batch Barcode"][0] = True
 
-    # finish paper pull button, validate ppg data
+    # 2. finish paper pull button, validate ppg data
     def checkPPGData(self):
         # Makes sure all ppg inputs are good, then stops timing
         # all_pass = True
@@ -553,7 +558,7 @@ class Prep(QMainWindow):
             self.ui.finishPull.setEnabled(False)
             self.ui.finish.setEnabled(True)
 
-    # finish button, save
+    # 3. finish button, save
     def saveData(self):
         print("Saving data...")
         self.saveDataToText()
@@ -1028,7 +1033,7 @@ class Prep(QMainWindow):
         return string
 
     ############################################################################
-    # Utility functions
+    # Utility
     ############################################################################
 
     def updateLineEdit(

--- a/guis/straw/prep/PrepGUI.py
+++ b/guis/straw/prep/PrepGUI.py
@@ -570,21 +570,20 @@ class Prep(QMainWindow):
         self.resetGUI()
 
     def saveDataToText(self):
-        timestamp = datetime.now()
         workers_str = ", ".join(
             self.sessionWorkers
         ).upper()  # Converts self.sessionWorkers to a string csv-style: "wk-worker01, wk-worker02, etc..."
-        self.saveStrawDataToText(timestamp, workers_str)
-        self.savePalletDataToText(timestamp, workers_str)
+        self.saveStrawDataToText(workers_str)
+        self.savePalletDataToText(workers_str)
 
-    def saveStrawDataToText(self, timestamp, workers_str):
+    def saveStrawDataToText(self, workers_str):
         file_name = self.stationID + "_" + self.palletNumber + ".csv"
         data_file = self.prepDirectory / file_name
         with open(data_file, "w+") as file:
             file.write("Station: " + self.stationID)
             header = "Timestamp, Pallet ID, Pallet Number, Paper pull time (H:M:S), workers ***NEWLINE***: Comments (optional)***\n"
             file.write(header)
-            file.write(timestamp.strftime("%Y-%m-%d_%H:%M") + ",")
+            file.write(datetime.now().strftime("%Y-%m-%d_%H:%M") + ",")
             file.write(self.palletID + ",")
             file.write(self.palletNumber + ",")
             file.write(
@@ -625,7 +624,7 @@ class Prep(QMainWindow):
 
             # Done creating data file
 
-    def savePalletDataToText(self, timestamp, workers_str):
+    def savePalletDataToText(self, workers_str):
         pfile = self.palletDirectory / self.palletID / str(self.palletNumber + ".csv")
         with open(pfile, "w+") as file:
             header = "Time Stamp, Task, 24 Straw Names/Statuses, Workers"
@@ -634,12 +633,12 @@ class Prep(QMainWindow):
             file.write(header)
 
             # Record Session Data
-            file.write(timestamp.strftime("%Y-%m-%d_%H:%M") + ",")  # Date
+            file.write(datetime.now().strftime("%Y-%m-%d_%H:%M") + ",")
+            file.write(self.palletID + ",")
             file.write(self.stationID + ",")
 
             # Record each straw and whether it passes/fails
             for i in range(24):
-
                 straw = self.strawIDs[i]
 
                 # If top straw doesn't exist, record save _'s for straw ID and pass_fail

--- a/guis/straw/removestraw.py
+++ b/guis/straw/removestraw.py
@@ -82,6 +82,7 @@ class removeStraw(QDialog):
                 if CPAL + ".csv" == pallet:
                     CPALID = pid
                     pfile = self.palletDirectory / pid / pallet
+                    print(pfile)
                     with open(pfile, "r") as file:
                         dummy = csv.reader(file)
                         history = []

--- a/guis/straw/removestraw.py
+++ b/guis/straw/removestraw.py
@@ -82,7 +82,6 @@ class removeStraw(QDialog):
                 if CPAL + ".csv" == pallet:
                     CPALID = pid
                     pfile = self.palletDirectory / pid / pallet
-                    print(pfile)
                     with open(pfile, "r") as file:
                         dummy = csv.reader(file)
                         history = []

--- a/guis/straw/removestraw.py
+++ b/guis/straw/removestraw.py
@@ -76,10 +76,12 @@ class removeStraw(QDialog):
         lastTask = ""
         straws = []
         passfail = []
-        for palletid in os.listdir(self.palletDirectory):
-            for pallet in os.listdir(self.palletDirectory / palletid):
+        CPALID = -1
+        for pid in os.listdir(self.palletDirectory):
+            for pallet in os.listdir(self.palletDirectory / pid):
                 if CPAL + ".csv" == pallet:
-                    pfile = self.palletDirectory / palletid / pallet
+                    CPALID = pid
+                    pfile = self.palletDirectory / pid / pallet
                     with open(pfile, "r") as file:
                         dummy = csv.reader(file)
                         history = []
@@ -101,7 +103,7 @@ class removeStraw(QDialog):
                                         passfail.append("Incomplete")
                                     else:
                                         passfail.append("Fail")
-        return CPAL, lastTask, straws, passfail
+        return CPAL, lastTask, straws, passfail, CPALID
 
     def displayPallet(self, CPAL, lastTask, straws, passfail):
         for palletid in os.listdir(self.palletDirectory):
@@ -127,7 +129,7 @@ class removeStraw(QDialog):
 
     def delete(self, btn):
         pos = int(btn.objectName().strip("remove_")) - 1
-        CPAL, lastTask, straws, passfail = self.getPallet(
+        CPAL, lastTask, straws, passfail, CPALID = self.getPallet(
             self.ui.palletLabel.text()[8:]
         )
         if straws[pos] == "Empty":
@@ -173,12 +175,12 @@ class removeStraw(QDialog):
                             if i != len(self.sessionWorkers) - 1:
                                 file.write(",")
                             i = i + 1
-        CPAL, lastTask, straws, passfail = self.getPallet(CPAL)
+        CPAL, lastTask, straws, passfail, CPALID = self.getPallet(CPAL)
         self.displayPallet(CPAL, lastTask, straws, passfail)
 
     def moveStraw(self, btn):
         pos = int(btn.objectName().strip("move_")) - 1
-        CPAL, lastTask, straws, passfail = self.getPallet(
+        CPAL, lastTask, straws, passfail, CPALID = self.getPallet(
             self.ui.palletLabel.text()[8:]
         )
 
@@ -279,7 +281,7 @@ class removeStraw(QDialog):
             )
             if not okPressed:
                 return
-            newpal, newlastTask, newstraws, newpassfail = self.getPallet(newpal)
+            newpal, newlastTask, newstraws, newpassfail, CPALID = self.getPallet(newpal)
             if newlastTask != lastTask:
                 buttonReply = QMessageBox.question(
                     self,
@@ -366,5 +368,5 @@ class removeStraw(QDialog):
                                     file.write(",")
                                 i = i + 1
 
-        CPAL, lastTask, straws, passfail = self.getPallet(CPAL)
+        CPAL, lastTask, straws, passfail, CPALID = self.getPallet(CPAL)
         self.displayPallet(CPAL, lastTask, straws, passfail)

--- a/guis/straw/resistance/measureByHand.py
+++ b/guis/straw/resistance/measureByHand.py
@@ -4,6 +4,7 @@ from PyQt5.QtGui import *
 from PyQt5.QtCore import pyqtSlot
 from guis.straw.resistance.multiMeter import MultiMeter
 import time
+from pyvisa.errors import VisaIOError
 
 
 class MeasureByHandPopup(QtWidgets.QDialog):
@@ -115,7 +116,7 @@ class MeasureByHandPopup(QtWidgets.QDialog):
             return
         try:
             self.multiMeter = MultiMeter()
-        except VISAIOError:
+        except VisaIOError:
             self.multiMeter = None
 
     def updateButtons(self):

--- a/guis/straw/resistance/multiMeter.py
+++ b/guis/straw/resistance/multiMeter.py
@@ -22,8 +22,8 @@
 #   Libraries: pyvisa (with NI-VISA backend)
 #
 
-import visa
 import pyvisa
+from pyvisa.errors import VisaIOError
 import time
 from datetime import datetime
 
@@ -31,17 +31,17 @@ from datetime import datetime
 class MultiMeter:
     def __init__(self):
         ##**Initializing VISA & DMM**##
-        self.rm = visa.ResourceManager()
+        self.rm = pyvisa.ResourceManager()
         try:
             self.dmm = self.rm.open_resource("USB0::0x0957::0x0607::MY47003138::INSTR")
             self.dmm.write("*rst; status:preset; *cls")
-        except pyvisa.errors.VisaIOError:
+        except VisaIOError:
             raise MultiMeterNotTurnedOn("TURN ON THE MULTIMETER!")
 
     def measure(self):
         try:
             return float(self.dmm.query_ascii_values("MEAS:RES?")[-1])
-        except pyvisa.errors.VisaIOError:
+        except VisaIOError:
             raise MultiMeterNotTurnedOn("TURN ON THE MULTIMETER!")
 
 

--- a/guis/straw/resistance/resistanceGUI.py
+++ b/guis/straw/resistance/resistanceGUI.py
@@ -2,7 +2,8 @@
 #
 # Straw Resistance Test GUI
 #
-# Read resistance data for a full panel of straws all at once from an Arduino Uno and PCB.
+# Read resistance data for a full panel of straws all at once from an Arduino
+# Uno and PCB. Save all the data at the very end.
 #
 # Next step:
 #
@@ -42,7 +43,7 @@ from PyQt5.QtWidgets import (
 )
 from guis.straw.resistance.design import Ui_MainWindow
 
-# from guis.straw.resistance.resistanceMeter import Resistance
+from guis.straw.resistance.resistanceMeter import Resistance
 from guis.straw.resistance.measureByHand import MeasureByHandPopup
 from guis.straw.removestraw import removeStraw
 from data.workers.credentials.credentials import Credentials
@@ -51,7 +52,7 @@ from guis.common.save_straw_workers import saveWorkers
 from guis.common.dataProcessor import SQLDataProcessor as DP
 from guis.common.gui_utils import generateBox
 
-from random import uniform
+# from random import uniform
 from enum import Enum, auto
 from guis.common.timer import QLCDTimer
 
@@ -128,7 +129,7 @@ class StrawResistanceGUI(QDialog):
 
         # Measurement classes
         self.removeStraw = removeStraw([])
-        # self.resistanceMeter = Resistance()  # resistance class
+        self.resistanceMeter = Resistance()  # resistance class
         self.byHandPopup = None  # Gets created later if necessary
 
         # Pallet Info
@@ -459,17 +460,19 @@ class StrawResistanceGUI(QDialog):
         self.DP.saveStart()  # initialize procedure and commit it to the DB
         self.procedure = self.DP.procedure  # Resistance(StrawProcedure) object
 
-        # try:
-        #    self.measurements = self.resistanceMeter.rMain()
-        # except FileNotFoundError as e:
-        #    print("File not found", e)
-        #    self.displayError(True)
-        #    return
-        # except:
-        #    print("Arduino Error")
-        #    self.displayError(True)
-        #    return
-        self.measurements = [[uniform(100, 900) for i in range(4)] for pos in range(24)]
+        try:
+            self.measurements = self.resistanceMeter.rMain()
+        except FileNotFoundError as e:
+            print("File not found", e)
+            self.displayError(True)
+            return
+        except:
+            print("Arduino Error")
+            self.displayError(True)
+            return
+
+        # useful for debug
+        # self.measurements = [[uniform(100, 900) for i in range(4)] for pos in range(24)]
 
         self.consolidateOldAndNewMeasurements()
 

--- a/guis/straw/resistance/resistanceGUI.py
+++ b/guis/straw/resistance/resistanceGUI.py
@@ -1,6 +1,5 @@
 #
-#   RESISTANCE TESTING v2.2
-#   Most Recent Update: 10/23/2018
+#   RESISTANCE TESTING
 #
 #   Author:    Joe Dill
 #   Email: <dillx031@umn.edu>
@@ -14,14 +13,6 @@
 #   Description:
 #       A Python3 script using PySerial to control and read from an Arduino Uno and PCB connected to a
 #       full pallet of straws. Returns the data in the in order to be displayed by the packaged GUI.
-#
-#   Updates in v 2.1:
-#       - Implements remove interface
-#           - View/edit pallet button
-#           - When saving, strawIDs and pass/fail written to pallet file
-#           - On open, user only needs to scan CPAL Number. All other info collected
-#
-#   Updates in v 2.2:
 #       - Implements Credentials Class
 #
 #   Packages: PySerial, Straw (custom wrapper class), Resistance (class controlling arduino)

--- a/guis/straw/resistance/resistanceMeter.py
+++ b/guis/straw/resistance/resistanceMeter.py
@@ -13,7 +13,7 @@ from guis.common.getresources import GetProjectPaths
 # os.system('mode con: cols=115 lines=50')
 com = "Com6"
 
-calibFile = GetProjectPaths()['strawresistancecal']
+calibFile = GetProjectPaths()["strawresistancecal"]
 dataFile = None
 measLet = "abcdefghijklmnop"
 
@@ -22,7 +22,7 @@ average = "average"
 try:
     cereal = serial.Serial(com, 9600, timeout=10)
     print(cereal.readline().decode("utf-8").rstrip())
-except:
+except serial.serialutil.SerialException:
     print("No Arduino Connected")
     sys.exit()
 


### PR DESCRIPTION
Follow a similar model as prep.

No need to make straws, straw location, or straw present entries, this time, though -- just resistance measurements in the meadurement_ohms table.

Lots of todos: frontend could use a timer and a display of the pallet number and ID. In the backend, should save the measurement method, and a _meaningful_ pass-fail value. Within the GUI, the flow control is wanting -- collect data does too much. Data bound for the database should be validated before committing.