### PR TITLE
Clear CPALs of All Present Straws at Prep Stage

### DIFF
--- a/guis/common/dataProcessor.py
+++ b/guis/common/dataProcessor.py
@@ -2396,6 +2396,7 @@ class SQLDataProcessor(DataProcessor):
     ##########################################################################
 
     # Create a procedure
+    # Record it in the DB, create/get a straw location
     def ensureProcedure(self):
         # If no procedure has been defined yet, define one.
         if self.procedure is None:

--- a/guis/common/db_classes/straw_location.py
+++ b/guis/common/db_classes/straw_location.py
@@ -271,6 +271,10 @@ class StrawLocation(BASE, OBJECT):
         straw_present.remove(commit)
         return straw_present
 
+    def removeAllStraws(self, commit=True):
+        for position in self.getFilledPositions():
+            self.removeStraw(position=position, commit=commit)
+
     def addStraw(self, straw, position, commit=True):
 
         # Make sure there's not already a straw there
@@ -483,7 +487,7 @@ class Pallet(StrawLocation):
     ):
         assert self._palletIsEmpty(
             pallet_id
-        ), "Unable to create pallet: pallet is not empty."
+        ), f"Unable to create pallet {number}: pallet {pallet_id} is not empty."
         super().__init__(
             location_type=location_type,
             number=number,

--- a/guis/straw/prep/PrepGUI.bat
+++ b/guis/straw/prep/PrepGUI.bat
@@ -1,4 +1,17 @@
 @ECHO OFF
 cls
 CD C:\Users\%USERNAME%\Desktop\Production
+
+REM=============================================================================
+REM Run a software update once-per-day
+REM=============================================================================
+set CUR_YYYY=%date:~10,4%
+set CUR_MM=%date:~4,2%
+set CUR_DD=%date:~7,2%
+set SUBFILENAME=C:\Users\mu2e\Desktop\MergeDownLogs\Updater_%CUR_YYYY%%CUR_MM%%CUR_DD%*
+if not exist %SUBFILENAME% (
+	echo Running software update!
+	call Updater.bat
+)
+
 python -m guis.straw.prep


### PR DESCRIPTION
At the moment, only the LPAL loader removes straws from a CPAL. In reality, many steps can remove straws from a CPAL.

Ultimately, we'll want to have each straw manually removed, and a non-empty CPAL at prep will be a problem.

Until then, the next step will be to check in on the status of the CPAL at the consolidation step, and remove straws at that point.