### PR TITLE
Separate Straw Leak Ino Ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ resources/networkDatabasePath.txt
 resources/dbvDatabasePath.txt
 resources/rootDirectory.txt
 resources/rootDirectoryLocation.txt
+resources/straw_leak_ino_ports.txt
 guis/straw/Prep GUI/dailytotal.txt
 guis/straw/Prep GUI/date.txt
 logfiles/

--- a/guis/common/getresources.py
+++ b/guis/common/getresources.py
@@ -31,6 +31,12 @@ def GetProjectPaths():
     return paths
 
 
+# list of strings ["COM1", "COM8", etc.]
+def GetStrawLeakInoPorts():
+    ports = pkg_resources.read_text(resources, "straw_leak_ino_ports.txt")
+    return [i.strip() for i in ports.split("\n")]
+
+
 def GetLocalDatabasePath():
     with pkg_resources.path(data, "database.db") as p:
         return str(p.resolve())

--- a/guis/straw/leak/LeakTestGUI.bat
+++ b/guis/straw/leak/LeakTestGUI.bat
@@ -1,4 +1,18 @@
 @ECHO OFF
 cls
+
 CD C:\Users\%USERNAME%\Desktop\Production\
+
+REM=============================================================================
+REM Run a software update once-per-day
+REM=============================================================================
+set CUR_YYYY=%date:~10,4%
+set CUR_MM=%date:~4,2%
+set CUR_DD=%date:~7,2%
+set SUBFILENAME=C:\Users\mu2e\Desktop\MergeDownLogs\Updater_%CUR_YYYY%%CUR_MM%%CUR_DD%*
+if not exist %SUBFILENAME% (
+	echo Running software update!
+	call Updater.bat
+)
+
 python -m guis.straw.leak

--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -42,7 +42,7 @@ from pathlib import Path
 
 from data.workers.credentials.credentials import Credentials
 from guis.straw.leak.remove import Ui_DialogBox
-from guis.common.getresources import GetProjectPaths
+from guis.common.getresources import GetProjectPaths, GetStrawLeakInoPorts
 from guis.common.save_straw_workers import saveWorkers
 
 # Import logger from Modules (only do this once)
@@ -74,18 +74,7 @@ class LeakTestStatus(QMainWindow):
         self.ui.setupUi(self)
         self.show()
         ## Add a timeout (0.08 sec) to avoid freezing GUI while waiting for serial data from arduinos
-        self.COM = [
-            "COM8",
-            "COM9",
-            "COM10",
-            "COM11",
-            "COM12",
-            "COM3",
-            "COM4",
-            "COM5",
-            "COM6",
-            "COM7",
-        ]
+        self.COM = GetStrawLeakInoPorts()
         self.COM_con = [None, None, None, None, None, None, None, None, None, None]
         self.arduino = [
             serial.Serial(port=self.COM_con[0], baudrate=115200, timeout=0.08),


### PR DESCRIPTION
Rather than hard code the arduino ports in the python file, read it in from a resource txt file.

Also, add the autoupdate to the leak test bat file.