### PR TITLE
Remove MR and Frame Requirements to Start Pro 6

### DIFF
--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -4655,7 +4655,7 @@ class panelGUI(QMainWindow):
             return
 
         # Ensure that all input data is valid
-        if not self.validateInput(indices=range(4)):
+        if not self.validateInput(indices=range(1)):
             return
 
         # Disable start button, panel input, and part inputs


### PR DESCRIPTION
Set range to one, this removes the requirement for middle ribs and frame in pro6.