### PR TITLE
Orange Straw Leak Rate

### DIFF
--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -1130,7 +1130,9 @@ class LeakTestStatus(QMainWindow):
         self.Chambers[chamber].setStyleSheet("background-color: rgb(225, 40, 40);")
 
     def setStrawStatus(self, chamber, passed):
-        if passed:
+        if passed and int(self.leak_rate[chamber]) < 2*10**(-5):
+            self.Chambers[chamber].setStyleSheet("background-color: rgb(225, 165, 0);")
+        elif passed:
             self.Chambers[chamber].setStyleSheet("background-color: rgb(40, 225, 40);")
         else:
             self.Chambers[chamber].setStyleSheet("background-color: rgb(225, 40, 40);")


### PR DESCRIPTION
If the straw leak rate is less than 2*10**(-5) sccm, then the leak test GUI turns orange in lieu of green. The only modified file was LeakTestGUI.py.