### PR TITLE
Remove strawroom merge

### DIFF
--- a/guis/common/getresources.py
+++ b/guis/common/getresources.py
@@ -33,7 +33,7 @@ def GetProjectPaths():
     #paths.update((k, Path(root + "/" + v)) for k, v in paths.items())
     for k,v in paths.items():
         # if not special strawroom things
-        if (k != "strawleakdata" and k!= "pallets"):
+        if (k != "strawleakcsv" and k!= "pallets"):
             # we want paths to remain on this machine
             paths.update({k : Path(root + "/" + v)})
         # otherwise (to prevent mergedown mayhem in strawroom)

--- a/guis/common/getresources.py
+++ b/guis/common/getresources.py
@@ -30,7 +30,7 @@ def GetProjectPaths():
     #paths.update((k, Path(root + "/" + v)) for k, v in paths.items())
     for k,v in paths.items():
         # if not special strawroom things
-        if (k != "strawleakcsv" and k!= "pallets"):
+        if (k != "leaktestresults" and k!= "pallets"):
             # we want paths to remain on this machine
             paths.update({k : Path(root + "/" + v)})
         # otherwise (to prevent mergedown mayhem in strawroom)

--- a/guis/common/getresources.py
+++ b/guis/common/getresources.py
@@ -27,9 +27,6 @@ def GetProjectPaths():
     # installation is created during setup.py.
     root = pkg_resources.read_text(resources, "rootDirectory.txt")
 
-    #for k,v in paths.items():
-    #    logger.debug(f'k = "{k}", v = "{v}"')
-
     #paths.update((k, Path(root + "/" + v)) for k, v in paths.items())
     for k,v in paths.items():
         # if not special strawroom things

--- a/guis/common/getresources.py
+++ b/guis/common/getresources.py
@@ -14,7 +14,6 @@ except ImportError:
 # Resources folder: where the paths.csv file is stored.
 import resources, data
 
-
 # Get a dictionary containing the important paths for this project.
 # Read in the csv file containing the directory locations.
 # Save them into a dictionary {name : path}.
@@ -27,7 +26,21 @@ def GetProjectPaths():
     # Make paths absolute. This txt file that holds the root/top dir of this
     # installation is created during setup.py.
     root = pkg_resources.read_text(resources, "rootDirectory.txt")
-    paths.update((k, Path(root + "/" + v)) for k, v in paths.items())
+
+    #for k,v in paths.items():
+    #    logger.debug(f'k = "{k}", v = "{v}"')
+
+    #paths.update((k, Path(root + "/" + v)) for k, v in paths.items())
+    for k,v in paths.items():
+        # if not special strawroom things
+        if (k != "strawleakdata" and k!= "pallets"):
+            # we want paths to remain on this machine
+            paths.update({k : Path(root + "/" + v)})
+        # otherwise (to prevent mergedown mayhem in strawroom)
+        else:
+            # save directly to the network
+            paths.update({k : Path("X:/" + v)})
+
     return paths
 
 

--- a/guis/straw/consolidate/consolidate_straws.py
+++ b/guis/straw/consolidate/consolidate_straws.py
@@ -27,7 +27,6 @@ kBLANKSTRAWSTRING = "_______"
 logger = SetupPANGUILogger("root", tag="straw_consolidate")
 
 leaktest_dir = GetProjectPaths()["strawleakdata"]
-#summary_file = leaktest_dir / "LeakTestResults.csv"
 summary_file = GetProjectPaths()["leaktestresults"]
 try:
     assert summary_file.is_file()

--- a/guis/straw/consolidate/consolidate_straws.py
+++ b/guis/straw/consolidate/consolidate_straws.py
@@ -27,7 +27,8 @@ kBLANKSTRAWSTRING = "_______"
 logger = SetupPANGUILogger("root", tag="straw_consolidate")
 
 leaktest_dir = GetProjectPaths()["strawleakdata"]
-summary_file = leaktest_dir / "LeakTestResults.csv"
+#summary_file = leaktest_dir / "LeakTestResults.csv"
+summary_file = GetProjectPaths()["leaktestresults"]
 try:
     assert summary_file.is_file()
 except AssertionError:

--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -1078,10 +1078,6 @@ class LeakTestStatus(QMainWindow):
     def editPallet(self):
         if self.checkCredentials():
             self.getCPALS()
-            # bad not good
-            #rem = removeStraw(
-            #    self.cpals, os.path.dirname(__file__) + "..\\..\\..\\Data\\Pallets\\"
-            #)
             rem = removeStraw(
                 self.cpals,
                 self.palletDirectoryLTSclass

--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -91,6 +91,7 @@ class LeakTestStatus(QMainWindow):
         ]
 
         self.leakDirectory = paths["strawleakdata"]
+        self.palletDirectoryLTSclass = paths["pallets"]
         self.leakDirectoryRaw = self.leakDirectory / "raw_data"
         self.leakDirectoryCom = self.leakDirectory / "comments"
         self.workerDirectory = paths["leakworkers"]
@@ -1077,8 +1078,13 @@ class LeakTestStatus(QMainWindow):
     def editPallet(self):
         if self.checkCredentials():
             self.getCPALS()
+            # bad not good
+            #rem = removeStraw(
+            #    self.cpals, os.path.dirname(__file__) + "..\\..\\..\\Data\\Pallets\\"
+            #)
             rem = removeStraw(
-                self.cpals, os.path.dirname(__file__) + "..\\..\\..\\Data\\Pallets\\"
+                self.cpals,
+                self.palletDirectoryLTSclass
             )
             rem.exec_()
         else:

--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -128,7 +128,7 @@ class LeakTestStatus(QMainWindow):
         self.files = {}
         # Passed straws with saved data
         self.straw_list = []
-        self.result = self.leakDirectory / "LeakTestResults.csv"
+        self.result = GetProjectPaths()["leaktestresults"]
 
         # what are these next two lines for??
         result = open(self.result, "a+", 1)
@@ -971,7 +971,7 @@ class LeakTestStatus(QMainWindow):
         ROW = int(chamber / 5)
         COL = chamber % 5
 
-        path = self.leakDirectory / "LeakTestResults.csv"
+        path = GetProjectPaths()["leaktestresults"]
 
         Current_worker = self.getWorker()
 

--- a/guis/straw/methane/methane_gui.py
+++ b/guis/straw/methane/methane_gui.py
@@ -139,7 +139,7 @@ import os, sys, subprocess
 logger = SetupPANGUILogger("root", tag="straw_consolidate")
 
 leaktest_dir = GetProjectPaths()["strawleakdata"]
-summary_file = leaktest_dir / "LeakTestResults.csv"
+summary_file = GetProjectPaths()["leaktestresults"]
 try:
     assert summary_file.is_file()
 except AssertionError:

--- a/guis/straw/methane/methane_gui.py
+++ b/guis/straw/methane/methane_gui.py
@@ -90,6 +90,13 @@ if __name__ == "__main__":
     cpal_id = cpal_id[-2:]
     cpal_num = input("Scan or type CPAL Number: ")
     cpal_num = cpal_num[-4:]
+    # if this code is ever uncommented this should use
+    # "from guis.common.getresources import GetProjectPaths"
+    # and "self.palletDirectory = paths["pallets"]" to get a path to the pallets directory
+    # otherwise bad things happen with the strawroom and merges and stuff
+    # with the two previous lines the next could be like this:
+    # "directory = ("C:self.palletDirectory\\CPALID" + cpal_id + "\\")
+
     directory = (
         "C:\\Users\\Mu2e\Desktop\\Production\\Data\\Pallets\\CPALID" + cpal_id + "\\"
     )

--- a/guis/straw/verification/addToStorage.py
+++ b/guis/straw/verification/addToStorage.py
@@ -3,10 +3,13 @@ import csv
 import os
 from datetime import datetime
 
+from guis.common.getresources import GetProjectPaths
+
 # sys.path.insert(0, '//MU2E-CART1/Database Backup/workers/credentials')
 # from credentials import *
 # from fixChildStraws import VerifyPrep
 def main():
+    palletDirectory = GetProjectPaths()["pallets"]
     total_date = str(datetime.today())
     date = total_date[5:7] + "/" + total_date[8:10] + "/" + total_date[0:4]
     string_hours = total_date[11:13]
@@ -34,8 +37,7 @@ def main():
     if p % 2 == 0:
         position = 92
     pathToPallet = (
-        os.path.dirname(__file__)
-        + "\\..\\..\\..\\Data\\Pallets\\"
+        palletDirectory
         + palID
         + "\\"
         + palNum

--- a/guis/straw/verification/makeLeakRateFile.py
+++ b/guis/straw/verification/makeLeakRateFile.py
@@ -3,10 +3,11 @@ import os
 from guis.common.getresources import GetProjectPaths
 
 leaktest_dir = GetProjectPaths()["strawleakdata"]
+leakresult_dir = GetProjectPaths()["leaktestresults"]
 leaktest_dir_old = GetProjectPaths()["leakdata"]
 
 pathlist = [
-    leaktest_dir / "LeakTestResults.csv",
+    leakresult_dir,
     leaktest_dir_old / "Leak Test Results.csv",
     leaktest_dir_old / "Leak test results old" / "Leak Test Results.csv",
     leaktest_dir_old / "Leak test results old" / "Old Leak Test Results.csv"

--- a/guis/straw/verification/verifyStorageStraw.py
+++ b/guis/straw/verification/verifyStorageStraw.py
@@ -220,7 +220,7 @@ class verifyStorageStraw:
                         )
 
                         # Record findings in leak_ratefile.csv
-                        with open(GetProjectPaths()["strawleakdata"] / "LeakTestResults.csv", "a") as leak_rate_file:
+                        with open(GetProjectPaths()["leaktestresults"], "a") as leak_rate_file:
                             leak_rate_file.write("\n")  # Newline
                             leak_rate_file.write(self.strawID + ",")  # Straw ID
                             leak_rate_file.write(

--- a/resources/paths.csv
+++ b/resources/paths.csv
@@ -16,6 +16,7 @@ lasercutfiles,guis/straw/laser/Cut_files
 laserdata,data/Laser cut data
 laserworkers,data/workers/straw workers/laser cutting
 leakdata,data/Leak test data/Leak Test Results
+leaktestresults,data/StrawLeak/LeakTestResults.csv
 leakworkers,data/workers/straw workers/leak testing
 listsDirectory,data/Panel Data/Lists/
 lpals,data\Loading Pallets


### PR DESCRIPTION
The main purpose of this branch is to eliminate the need for the strawrooms frequent mergedowns.
This has been done by changing the utility function (GetProjectPaths() from getresources.py) that provides the paths for data/Pallets and data/StrawLeak/LeakTestResults.csv to give paths directly to the network.  A new path was added for LeakTestResults.csv because it's not necessary or desired to be saving everything in that folder directly to the network.

I also ensured that all the strawroom scripts/programs do not use any "w" mode in context managers, that the context managers are open for a short duration, and that all the scripts/programs use GetProjectPaths() instead of hard-coded paths.