### PR TITLE
Quick fix to speed up LeakTestGUI.py

### DIFF
--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -91,7 +91,7 @@ class LeakTestStatus(QMainWindow):
         ]
 
         self.leakDirectory = paths["strawleakdata"]
-        self.palletDirectoryLTSclass = paths["pallets"]
+        self.palletDirectoryLTSclass = paths["palletsLTG"]
         self.leakDirectoryRaw = self.leakDirectory / "raw_data"
         self.leakDirectoryCom = self.leakDirectory / "comments"
         self.workerDirectory = paths["leakworkers"]
@@ -128,7 +128,7 @@ class LeakTestStatus(QMainWindow):
         self.files = {}
         # Passed straws with saved data
         self.straw_list = []
-        self.result = GetProjectPaths()["leaktestresults"]
+        self.result = GetProjectPaths()["leaktestresultsLTG"]
 
         # what are these next two lines for??
         result = open(self.result, "a+", 1)
@@ -971,7 +971,7 @@ class LeakTestStatus(QMainWindow):
         ROW = int(chamber / 5)
         COL = chamber % 5
 
-        path = GetProjectPaths()["leaktestresults"]
+        path = GetProjectPaths()["leaktestresultsLTG"]
 
         Current_worker = self.getWorker()
 

--- a/resources/paths.csv
+++ b/resources/paths.csv
@@ -17,11 +17,13 @@ laserdata,data/Laser cut data
 laserworkers,data/workers/straw workers/laser cutting
 leakdata,data/Leak test data/Leak Test Results
 leaktestresults,data/StrawLeak/LeakTestResults.csv
+leaktestresultsLTG,data/StrawLeak/LeakTestResults.csv
 leakworkers,data/workers/straw workers/leak testing
 listsDirectory,data/Panel Data/Lists/
 lpals,data\Loading Pallets
 moldReleasePath,data/Panel Data/Mold Release/Mold Release.csv
 pallets,data/Pallets
+palletsLTG,data/Pallets
 panelDirectory,data/Panel Data
 panelresistancedata,data/Panel Data/FinalQC/Resistance
 panelleak,data/Panel data/FinalQC/Leak/Plots


### PR DESCRIPTION
- last big update changed paths for leak test results and pallets from local to network
- that eliminated the need for mergedowns in lots of places but slowed down LeakTestGUI.py
- this commit undos the previous update for just LeakTestGUI.py
- mergedowns will be needed before and after the use of LeakTestGUI.py