### PR TITLE
Methane Form TXT Save

### DIFF
--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -5786,8 +5786,6 @@ class panelGUI(QMainWindow):
             bot_high = None
             top_straws=False
             bottom_straws=False
-            print(self.ui.ts_low.text())
-            print(self.ui.bs_low.text())
             if self.ui.ts_low.text() != '':
                 try:
                     top_low = int(self.ui.ts_low.text())
@@ -5840,6 +5838,9 @@ class panelGUI(QMainWindow):
             
             # end current methane test, setting current to 0 in db
             MethaneTestSession.end_methane_test(user)    
+            
+            # save the methane session in txt file
+            self.DP.saveMethaneSession(True,covered_locations,sep_layer,top_low,top_high,bot_low,bot_high,gas_detector,user)
             
             # clear fields
             self.ui.top_covers.setChecked(False)


### PR DESCRIPTION
Methane sessions and leaks are now saved in txt format, in addition to the db. Modifications were made to dataprocessor.py, as well as to pangui.py.