### PR TITLE
Straw Leak CPAL Search Upgrade

### DIFF
--- a/guis/straw/checkstraw.py
+++ b/guis/straw/checkstraw.py
@@ -19,10 +19,9 @@ class Check:
 
     def findPalletFiles(self, CPAL):
         pfiles = []
-        for palletid in os.listdir(self.palletDirectory):
-            for pallet in os.listdir(self.palletDirectory / palletid):
-                if CPAL + ".csv" == pallet:
-                    pfiles.append(self.palletDirectory / palletid / pallet)
+        for file in Path(self.palletDirectory).rglob("*"):
+            if file.is_file() and file.suffix == '.csv' and file.stem == CPAL:
+                pfiles.append(file)
         return pfiles
 
     def strawPass(self, CPAL, straw, step):

--- a/guis/straw/leak/LeakTestGUI.py
+++ b/guis/straw/leak/LeakTestGUI.py
@@ -1067,7 +1067,7 @@ class LeakTestStatus(QMainWindow):
                 strawname = self.Choosenames[ROW][COL][:7]
 
                 try:
-                    cpal = FindCPAL(strawname)[1]
+                    cpal = FindCPALContainingStraw(strawname)[1]
                     if cpal not in self.cpals:
                         self.cpals.append(cpal)
                 except StrawNotFoundError:

--- a/guis/straw/leak/WriteToFile.py
+++ b/guis/straw/leak/WriteToFile.py
@@ -36,52 +36,81 @@ def ExtractPreviousStrawData(path):
     return test_name, names, pf
 
 
-def FindCPAL(strawname):
-    # Returns (CPALID, CPAL) of straw number
-    # If a straw is associated with more than one CPALID, use the largest (i.e.
-    # most recent) one.
-    cpal_return_pairs = []
-    database_path = GetProjectPaths()["palletsLTG"]
-    for i in range(1, 25):
-        files = []
-        cpalid = "CPALID" + str(i).zfill(2)
-        path = database_path / cpalid
+# Get list of all CPALs (CPALID, CPAL#), whose files contain strawname
+def FindAllCPALsContainingStraw(strawname):
+    cpals = []
+    # "LTG" == leak test GUI, i.e. local data folder
+    pallets_data_dir = GetProjectPaths()["palletsLTG"]
+    for file in Path(pallets_data_dir).rglob("*"):
+        if file.is_file() and file.suffix == '.csv':
+            cpalid = file.parent.name
+            assert "CPALID" in cpalid and int(cpalid[-2:]) and len(cpalid) == 8
 
-        for (dirpath, dirnames, filenames) in os.walk(path):
-            files.extend(filenames)
-            break
+            cpal = file.stem[:-4]
+            assert "CPAL" in cpal and int(cpal[-4]) and len(cpal) == 8
 
-        for filename in files:
-            f = open(path / filename, "r")
+            with open(file, "r") as f:
+                if strawname.lower() in f.read.lower():
+                    cpals.append((cpalid, cpal))
+    return cpals
 
-            line = f.readline()
 
-            while line != "":
-                if strawname.lower() in line.lower():
-                    cpal_return_pairs.append((cpalid, filename[:-4]))
+def GetLastLineOfPalletFile(cpalid, cpal):
+    cpal_file = GetProjectPaths()["pallets"] / cpalid / str(cpal + ".csv")
+    assert cpal_file.is_file()
+    # Files are only few lines, so OK to read like this
+    with open (cpal_file, "r") as f:
+        last_line = f.readlines()[-1]
+    return last_line
 
-                line = f.readline()
 
-            f.close()
+# Get CPAL file containing straw name.
+# If multiple, pick one with straw in final line or most recent
+def FindCPALContainingStraw(strawname):
+    cpals = FindAllCPALsContainingStraw(strawname)
 
-    # return the (cpalid,cpal) pair that has the highest cpal.
-    # e.g. max([('CPAL01', 'CPAL0123'), ('CPAL01, 'CPAL6798')]), the max
-    # function is performed on 'CPAL0123' vs 'CPAL6789', and 'CPAL6789' wins.
-    if cpal_return_pairs:
-        cpal_return_pairs = [i for i in cpal_return_pairs if i[1] != "CPAL9999"]
-        ret = max(cpal_return_pairs, key=lambda pair: pair[1])
-        # print(ret)
-        # print("CPAL", ret[1],"for straw", strawname, "found")
-        return ret
+    cpals = [i for i in cpals if "CPAL9999" != i[1]]
+    cpals = list(set(cpals))  # remove duplicates
 
-    raise StrawNotFoundError
+    if not cpals:
+        logger.error("FindCPALContainingStraw: no cpals found for {strawname}".)
+        raise StrawNotFoundError
+
+    # get cpals with strawname in final line
+    cpals_with_straw_in_final_line = {} # {(cpalid, cpal#) : timestamp, ...}
+    for c in cpals:
+        last_line = GetLastLineOfPalletFile(c[0], c[1])
+        last_line = last_line.split(",")
+        straw_idx = last_line.lower().find(strawname.lower())
+
+        if straw_idx and last_line[straw_idx + 1] = "P":
+            timestamp_last_line = last_line[0]
+            try:
+                timestamp_last_line = datetime.strptime(timestamp_last_line, '%Y-%m-%d_%H:%M')
+            except ValueError:
+                logger.error("CPAL FILE WITH A DIFFERENT TIME FORMAT. PLEASE INFORM BEN.")
+                sys.exit()
+            cpals_with_straw_in_final_line[c] = timestamp_last_line
+
+    # If just one such file, return that one
+    # If multiple, return most recent one
+    # returning (CPAL, CPALID)
+    if len(cpals_with_straw_in_final_line) == 0:
+        logger.error(f"Straw not found in final line of any of these cpal files {cpals}.")
+        return StrawNotFoundError
+    elif len(cpals_with_straw_in_final_line) == 1:
+        return cpals_with_straw_in_final_line[0]
+    else:
+        logger.info(f"Straw {strawname} found in the final line of multiple pallet files.")
+        logger.info(f"Choosing the pallet file with the most recent timestamp.")
+        return max(cpals_with_straw_in_final_line, key=cpals_with_straw_in_final_line.get)
 
 
 def UpdateStrawInfo(test, workers, strawname, result):
     # Save data to appropriate CPAL file
     database_path = GetProjectPaths()["palletsLTG"]
 
-    (cpalid, cpal) = FindCPAL(strawname)
+    (cpalid, cpal) = FindCPALContainingStraw(strawname)
 
     path = database_path / cpalid / str(cpal + ".csv")
 
@@ -246,7 +275,7 @@ def checkPass(path, strawname, current_test):
 def checkStraw(strawname, expected_previous_test, current_test):
     database_path = GetProjectPaths()["palletsLTG"]
 
-    (cpalid, cpal) = FindCPAL(strawname)
+    (cpalid, cpal) = FindCPALContainingStraw(strawname)
 
     path = database_path / cpalid / str(cpal + ".csv")
 


### PR DESCRIPTION
CPAL preparing has gotten more involved recently, esp since we started doing the many-retests experiment.

No longer is the pallet with the highest number necessarily the one where a straw should be located.

Make the search-pallet-files-containing-strawname more sophisticated: between two files containing strawname, choose the one which has the straw in the final line of the file. When multiple files satisfy _that_ criterion, use the one with the latest timestamp.