### PR TITLE
Added query specificity for methane form

### DIFF
--- a/guis/common/db_classes/measurements_panel.py
+++ b/guis/common/db_classes/measurements_panel.py
@@ -288,10 +288,11 @@ class MethaneTestSession(BASE, OBJECT):
         
     # returns the methane session data
     @classmethod
-    def get_methane_session(cls):
+    def get_methane_session(cls,user):
         query_result = (
             DM.query(cls)
             .filter(cls.current == 1)
+            .filter(cls.user == user)
         )
         query_result=query_result.all()[0]
         return(query_result.id,query_result.session,query_result.current,query_result.covered_areas,query_result.sep_layer,query_result.top_straw_low,query_result.top_straw_high,query_result.bot_straw_low,query_result.bot_straw_high,query_result.user)

--- a/guis/panel/pangui/pangui.py
+++ b/guis/panel/pangui/pangui.py
@@ -5877,7 +5877,12 @@ class panelGUI(QMainWindow):
                 
                 location = int(self.ui.leak_location.text())
                 leak_size = int(self.ui.leak_size_straw.text())
-                session = int(MethaneTestSession.get_methane_session()[1])
+                
+                user=""
+                for i in self.Current_workers:
+                    if i.text() is not None:
+                        user=user+' '+i.text()
+                session = int(MethaneTestSession.get_methane_session(user)[1])
             except:
                 generateBox(
                     "critical", "Warning", "Please ensure that all inputs are valid."
@@ -5920,7 +5925,12 @@ class panelGUI(QMainWindow):
             # acquire data from the gui entry fields
             try:
                 leak_size = int(self.ui.leak_size_panel.text())
-                session = int(MethaneTestSession.get_methane_session()[1])
+                
+                user=""
+                for i in self.Current_workers:
+                    if i.text() is not None:
+                        user=user+' '+i.text()
+                session = int(MethaneTestSession.get_methane_session(user)[1])
             except:
                 generateBox(
                     "critical", "Warning", "Please ensure that all inputs are valid."


### PR DESCRIPTION
When searching for a methane session, the query utilizes the username in addition to is_current. This will ensure that sessions aren't improperly updated. Updated files are measurements_panel.py and pangui.py.