### PR TITLE
Multiple co2 Epoxy

### DIFF
--- a/guis/common/db_classes/procedure.py
+++ b/guis/common/db_classes/procedure.py
@@ -473,3 +473,14 @@ class PanelProcedure(Procedure):
 class StrawProcedure(Procedure):
     def __init__(self, station, straw_location, create_key):
         super().__init__(station, straw_location, create_key)
+    
+class Co2StrawProcedure(Procedure):
+    def _init_details(self):
+        try:
+            dc = self._getDetailsClass()
+        except Exception:
+            dc = None
+        if dc is None:
+            print('got none')
+            return
+        self.details = dc(id=self.ID(),procedure=self.id)

--- a/guis/common/db_classes/procedure.py
+++ b/guis/common/db_classes/procedure.py
@@ -473,14 +473,3 @@ class PanelProcedure(Procedure):
 class StrawProcedure(Procedure):
     def __init__(self, station, straw_location, create_key):
         super().__init__(station, straw_location, create_key)
-    
-class Co2StrawProcedure(Procedure):
-    def _init_details(self):
-        try:
-            dc = self._getDetailsClass()
-        except Exception:
-            dc = None
-        if dc is None:
-            print('got none')
-            return
-        self.details = dc(id=self.ID(),procedure=self.id)

--- a/guis/common/db_classes/procedures_straw.py
+++ b/guis/common/db_classes/procedures_straw.py
@@ -191,7 +191,7 @@ class SilvProcedure(StrawProcedure):
     dp190       INTEGER,
     timestamp   INTEGER NOT NULL
 """
-class CO2(StrawProcedure):
+class CO2(Co2StrawProcedure):
     __mapper_args__ = {"polymorphic_identity": "co2"}
 
     def __init__(self, station, straw_location, create_key):

--- a/guis/common/db_classes/procedures_straw.py
+++ b/guis/common/db_classes/procedures_straw.py
@@ -191,7 +191,7 @@ class SilvProcedure(StrawProcedure):
     dp190       INTEGER,
     timestamp   INTEGER NOT NULL
 """
-class CO2(Co2StrawProcedure):
+class CO2(StrawProcedure):
     __mapper_args__ = {"polymorphic_identity": "co2"}
 
     def __init__(self, station, straw_location, create_key):
@@ -200,6 +200,17 @@ class CO2(Co2StrawProcedure):
         ), f"Error. Tried to construct co2 procedure for a station '{station.id}' not 'co2'."
         # creates/gets entries in procedure table and procedure_details_co2
         super().__init__(station, straw_location, create_key)
+    
+    def _init_details(self):
+        try:
+            dc = self._getDetailsClass()
+        except Exception:
+            dc = None
+        if dc is None:
+            print('got none')
+            return
+
+        self.details = dc(id=self.ID(),procedure=self.id)
 
     def _getDetailsClass(self):
         class Details(BASE, OBJECT):
@@ -209,6 +220,7 @@ class CO2(Co2StrawProcedure):
             epoxy_batch = Column(Integer)
             epoxy_time = Column(Integer)
             dp190 = Column(Integer)
+
 
         return Details
 


### PR DESCRIPTION
In procedures_straw.py redefined the _init_details function to ensure that multiple entries with the same procedure may be put into the procedure_details_co2 table.

Accompanying changes to the db:
     - Procedure column in procedure_details_co2 is no longer unique.
     - Trigger now updates timestamp by entry id rather than procedure.