### PR TITLE
Further Assorted DBViewer Heating Modifications

### DIFF
--- a/guis/dbviewer/facileDBMain.py
+++ b/guis/dbviewer/facileDBMain.py
@@ -2524,7 +2524,7 @@ class facileDBGUI(QMainWindow):
 
         # make subplot for PAAS A
         labelAddOn = "of PAAS A " if pro == 1 else ""
-        plt.subplot(211)
+        plt.subplots(1,1,figsize=(12,7))
         plt.grid(color='k', linestyle='-', linewidth=1)
         plt.plot_date(xData, yDataA, label="PAAS A", markersize=2)  # make plot
         mpl.dates.HourLocator()

--- a/guis/dbviewer/facileDBMain.py
+++ b/guis/dbviewer/facileDBMain.py
@@ -989,7 +989,7 @@ class facileDBGUI(QMainWindow):
         if time_begin_above_50_paasB is not None:
             time_begin_above_50_paasB = datetime.fromtimestamp(time_begin_above_50_paasB)
         if time_end_above_50_paasB is not None:
-            time_end_above_50_paasB = datetime.fromtimestamp(time_begin_above_50_paasB)
+            time_end_above_50_paasB = datetime.fromtimestamp(time_end_above_50_paasB)
         
         # return all pertinent values
         return paasATemps, paasBTemps, time_begin_above_50_paasA, time_end_above_50_paasA, time_begin_above_50_paasB, time_end_above_50_paasB, elapsed_time_above_50_paasA, elapsed_time_above_50_paasB

--- a/guis/dbviewer/facileDBMain.py
+++ b/guis/dbviewer/facileDBMain.py
@@ -2525,6 +2525,7 @@ class facileDBGUI(QMainWindow):
         # make subplot for PAAS A
         labelAddOn = "of PAAS A " if pro == 1 else ""
         plt.subplot(211)
+        plt.grid(color='k', linestyle='-', linewidth=1)
         plt.plot_date(xData, yDataA, label="PAAS A", markersize=2)  # make plot
         mpl.dates.HourLocator()
         plt.xlabel("Time", fontsize=20)  # set x axis label

--- a/guis/dbviewer/facileDBMain.py
+++ b/guis/dbviewer/facileDBMain.py
@@ -2248,8 +2248,8 @@ class facileDBGUI(QMainWindow):
                 # make a list of stats
                 paasAStats = [
                     "PAAS A Statistics",
-                    f'Mean: {str(statistics.mean(paasATemps))[:8]}',  # mean of paas A
-                    f'Max: {str(max(paasATemps))[:8]}',  # max of paas A
+                    f'Mean: {str(round(statistics.mean(paasATemps),1))[:8]}',  # mean of paas A
+                    f'Max: {str(round(max(paasATemps),1))[:8]}',  # max of paas A
                     f'First time above 50 C: {str(time_begin_above_50_paasA)}', # first time paas A went above 50 C
                     f'Last time above 50 C: {str(time_end_above_50_paasA)}', # last time paas A dipped below 50 C
                     f'Elapsed time above 50 C (hours): {str(elapsed_time_above_50_paasA)}', # time between first going above and finally dipping below 50 C
@@ -2261,8 +2261,8 @@ class facileDBGUI(QMainWindow):
                 paasBCStats = [
                     '', # empty line
                     f'PAAS {"B" if pro == 2 else "C"} Statistics',
-                    f'Mean: {str(statistics.mean(paasBCTemps))[:8]}',  # mean of paas BC
-                    f'Max: {str(max(paasBCTemps))[:8]}',  # max of paas BC
+                    f'Mean: {str(round(statistics.mean(paasBCTemps),1))[:8]}',  # mean of paas BC
+                    f'Max: {str(round(max(paasBCTemps),1))[:8]}',  # max of paas BC
                     f'First time above 50 C: {str(time_begin_above_50_paasB)}', # first time paas BC went above 50 C
                     f'Last time above 50 C: {str(time_end_above_50_paasB)}', # last time paas BC dipped below 50 C
                     f'Elapsed time above 50 C (hours): {str(elapsed_time_above_50_paasB)}', # time between first going above and finally dipping below 50 C

--- a/guis/dbviewer/facileDBMain.py
+++ b/guis/dbviewer/facileDBMain.py
@@ -2253,8 +2253,6 @@ class facileDBGUI(QMainWindow):
                     f'First time above 50 C: {str(time_begin_above_50_paasA)}', # first time paas A went above 50 C
                     f'Last time above 50 C: {str(time_end_above_50_paasA)}', # last time paas A dipped below 50 C
                     f'Elapsed time above 50 C (hours): {str(elapsed_time_above_50_paasA)}', # time between first going above and finally dipping below 50 C
-                    f'Upper σ: {str(statistics.mean(paasATemps) - statistics.stdev(paasATemps))[:8]}',  # upper std dev
-                    f'Lower σ: {str(statistics.mean(paasATemps) + statistics.stdev(paasATemps))[:8]}',  # lower std dev
                 ]
             else:
                 paasAStats = []
@@ -2268,8 +2266,6 @@ class facileDBGUI(QMainWindow):
                     f'First time above 50 C: {str(time_begin_above_50_paasB)}', # first time paas BC went above 50 C
                     f'Last time above 50 C: {str(time_end_above_50_paasB)}', # last time paas BC dipped below 50 C
                     f'Elapsed time above 50 C (hours): {str(elapsed_time_above_50_paasB)}', # time between first going above and finally dipping below 50 C
-                    f'Upper σ: {str(statistics.mean(paasBCTemps) - statistics.stdev(paasBCTemps))[:8]}',  # upper std dev
-                    f'Lower σ: {str(statistics.mean(paasBCTemps) + statistics.stdev(paasBCTemps))[:8]}',  # lower std dev
                 ]
             else:
                 paasBCStats = []


### PR DESCRIPTION
Made assorted dbv heater modifications, none of which required GUI work. Changes were limited to the facileDBMain.py file.

- Added gridlines to the popup heater window.
- Increased the initial size of the popup heater window.
- Removed all sigma data from the heater area.
- Ensured that all data in the heater area is rounded to the nearest tenth.